### PR TITLE
[PEPC-Boost][3] ToB bid auction implementation

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1762,6 +1762,10 @@ func (api *RelayAPI) handleSubmitNewTobTxs(w http.ResponseWriter, req *http.Requ
 	// This is already solved and should be straightforward to implement. its basically simulation
 	// with some additional checks
 
+	// TODO - bchain - if a searcher submits these ToB txs in the same slot they want to include in the block,
+	// we might miss out on higher value RoB blocks that are submitted in the same slot but before the searcher
+	// submits the ToB txs. This is more complicated to implement, so we can pick it up later
+
 	// add the tob tx to the redis cache
 	err = api.redis.SetTobTx(context.Background(), tx, slot, parentHash, transactionBytes)
 	if err != nil {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1738,12 +1738,6 @@ func (api *RelayAPI) handleSubmitNewTobTxs(w http.ResponseWriter, req *http.Requ
 
 	lastTx := txs[len(txs)-1]
 
-	err = api.checkTobTxsStateInterference(txs)
-	if err != nil {
-		log.WithError(err).Warn("could not validate tob txs")
-		api.RespondError(w, http.StatusInternalServerError, err.Error())
-	}
-
 	tx := api.redis.NewTxPipeline()
 
 	tobTxValue := lastTx.Value()

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1610,8 +1610,6 @@ func (api *RelayAPI) checkTobTxsStateInterference(txs []*types.Transaction) erro
 		return fmt.Errorf("we support only 1 tx on the TOB currently, got %d", len(txs))
 	}
 
-	// TODO - check if nonce is valid
-	// TODO - check if tx has already been included in a block
 	firstTx := txs[0]
 	if firstTx.To() == nil {
 		return fmt.Errorf("contract creation cannot be a TOB tx")
@@ -1625,19 +1623,12 @@ func (api *RelayAPI) checkTobTxsStateInterference(txs []*types.Transaction) erro
 	return nil
 }
 
-// This method checks the following:
-// 1. If the tx has already been included in a block
-// 2. If the user sending the tx has enough balance to pay for the tx
-// 3. If the sender nonce is valid
-// 4. Checks if the final tx is a validator payout
+// This method first checks whether the payouts are valid, then checks whether the txs are valid w.r.t state interference
 func (api *RelayAPI) checkTxAndSenderValidity(txs []*types.Transaction, log *logrus.Entry) error {
-	// TODO - ALL PAYOUT RELATED THINGS!
-	// TODO - Finish the payout tx validation like check the sender account balance. We don't have to validate the builder payout txs. The onus of
-	// it falls on the builder
-	// TODO - we need to add a new tx to the TOB txs which sends the payout from the relayer to the validator and the builder. Pick this up once other things are done
+	// TODO - Payouts still need to be modelled
 	// TODO - check all the txs to see if the nonce is valid, value is valid, check if the tx has already been included. These can be confirmed from the
 	// execution layer. We should ideally
-	// TODO - Add state interference checks as in checkTobTxsStateInterference
+	// TODO - expand state interference checks as in checkTobTxsStateInterference
 
 	// Start: Payout checks
 	lastTx := txs[len(txs)-1]
@@ -1659,11 +1650,8 @@ func (api *RelayAPI) checkTxAndSenderValidity(txs []*types.Transaction, log *log
 }
 
 func (api *RelayAPI) handleSubmitNewTobTxs(w http.ResponseWriter, req *http.Request) {
-	//var pf common.Profile
-	//var prevTime, nextTime time.Time
 	headSlot := api.headSlot.Load()
 	receivedAt := time.Now().UTC()
-	//prevTime = receivedAt
 
 	log := api.log.WithFields(logrus.Fields{
 		"method":                "submitTobTxs",
@@ -1736,7 +1724,7 @@ func (api *RelayAPI) handleSubmitNewTobTxs(w http.ResponseWriter, req *http.Requ
 		api.RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if len(txs) == 1 {
+	if len(txs) < 2 {
 		log.Error("We require a payment tx along with the TOB txs!")
 		api.Respond(w, http.StatusBadRequest, "We require a payment tx along with the TOB txs!")
 		return

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1630,6 +1630,10 @@ func (api *RelayAPI) checkTxAndSenderValidity(txs []*types.Transaction, log *log
 	// execution layer. We should ideally
 	// TODO - expand state interference checks as in checkTobTxsStateInterference
 
+	if len(txs) < 2 {
+		return fmt.Errorf("We require a payment tx along with the TOB txs!")
+	}
+
 	// Start: Payout checks
 	lastTx := txs[len(txs)-1]
 
@@ -1724,15 +1728,10 @@ func (api *RelayAPI) handleSubmitNewTobTxs(w http.ResponseWriter, req *http.Requ
 		api.RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if len(txs) < 2 {
-		log.Error("We require a payment tx along with the TOB txs!")
-		api.Respond(w, http.StatusBadRequest, "We require a payment tx along with the TOB txs!")
-		return
-	}
 
 	err = api.checkTxAndSenderValidity(txs, log)
 	if err != nil {
-		log.WithError(err).Warn("error validating the txs")
+		log.WithError(err).Error("error validating the txs")
 		api.RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1626,9 +1626,7 @@ func (api *RelayAPI) checkTobTxsStateInterference(txs []*types.Transaction) erro
 // This method first checks whether the payouts are valid, then checks whether the txs are valid w.r.t state interference
 func (api *RelayAPI) checkTxAndSenderValidity(txs []*types.Transaction) error {
 	// TODO - Payouts still need to be modelled
-	// TODO - check all the txs to see if the nonce is valid, value is valid, check if the tx has already been included. These can be confirmed from the
-	// execution layer. We should ideally
-	// TODO - expand state interference checks as in checkTobTxsStateInterference
+	// TODO - expand state interference checks as in checkTobTxsStateInterference using call tracing
 
 	if len(txs) == 0 {
 		return fmt.Errorf("Empty TOB tx request sent!")

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1624,13 +1624,16 @@ func (api *RelayAPI) checkTobTxsStateInterference(txs []*types.Transaction) erro
 }
 
 // This method first checks whether the payouts are valid, then checks whether the txs are valid w.r.t state interference
-func (api *RelayAPI) checkTxAndSenderValidity(txs []*types.Transaction, log *logrus.Entry) error {
+func (api *RelayAPI) checkTxAndSenderValidity(txs []*types.Transaction) error {
 	// TODO - Payouts still need to be modelled
 	// TODO - check all the txs to see if the nonce is valid, value is valid, check if the tx has already been included. These can be confirmed from the
 	// execution layer. We should ideally
 	// TODO - expand state interference checks as in checkTobTxsStateInterference
 
-	if len(txs) < 2 {
+	if len(txs) == 0 {
+		return fmt.Errorf("Empty TOB tx request sent!")
+	}
+	if len(txs) == 1 {
 		return fmt.Errorf("We require a payment tx along with the TOB txs!")
 	}
 
@@ -1729,7 +1732,7 @@ func (api *RelayAPI) handleSubmitNewTobTxs(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	err = api.checkTxAndSenderValidity(txs, log)
+	err = api.checkTxAndSenderValidity(txs)
 	if err != nil {
 		log.WithError(err).Error("error validating the txs")
 		api.RespondError(w, http.StatusBadRequest, err.Error())


### PR DESCRIPTION
## 📝 Summary

This PR contains the implementation of the ToB bid auction. We implement the `relay/v1/builder/tob_txs` API to which searchers bid their ToB tx with a payout to the relayer. The following is the format of the request type.

```
type TobTxsSubmitRequest struct {
	TobTxs     utilbellatrix.ExecutionPayloadTransactions // binary marshalled ToB tx including the payout
	Slot       uint64 // slot at which the searcher wants the ToB txs to be proposed.
	ParentHash string // the parent hash of the block on top of which the searcher wants their txs to be included
}
```

UPDATE: The payout is now being sent to the proposer fee recipient. This has been updated in https://github.com/bharath-123/pepc-boost-relay/pull/19
