### PR TITLE
[PEPC-Boost][9] Tx tracing infra types

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -17,6 +17,8 @@ import (
 	consensuscapella "github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	utilbellatrix "github.com/attestantio/go-eth2-client/util/bellatrix"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	boostTypes "github.com/flashbots/go-boost-utils/types"
 )
@@ -916,4 +918,31 @@ func (b *BlockAssemblerRequest) UnmarshalJSON(data []byte) error {
 	b.RobPayload = *blockRequest
 
 	return nil
+}
+
+// callLog is the result of LOG opCode
+type CallLog struct {
+	Address common.Address `json:"address"`
+	Topics  []common.Hash  `json:"topics"`
+	Data    hexutil.Bytes  `json:"data"`
+}
+
+type CallTrace struct {
+	From         common.Address  `json:"from"`
+	Gas          *hexutil.Uint64 `json:"gas"`
+	GasUsed      *hexutil.Uint64 `json:"gasUsed"`
+	To           *common.Address `json:"to,omitempty"`
+	Input        hexutil.Bytes   `json:"input"`
+	Output       hexutil.Bytes   `json:"output,omitempty"`
+	Error        string          `json:"error,omitempty"`
+	RevertReason string          `json:"revertReason,omitempty"`
+	Calls        []CallTrace     `json:"calls,omitempty"`
+	Logs         []CallLog       `json:"logs,omitempty"`
+	Value        *hexutil.Big    `json:"value,omitempty"`
+	// Gencodec adds overridden fields at the end
+	Type string `json:"type"`
+}
+
+type CallTraceResponse struct {
+	Result CallTrace `json:"result"`
 }


### PR DESCRIPTION
## 📝 Summary

Types for the infra to do complex state interference checks. To perform adequate state interference checks, we are using the callTracer. The call tracer allows us to look into the individual calls of a particular tx which can't otherwise be inferred from from the input data field of a tx.

The types are copied from https://github.com/ethereum/go-ethereum/blob/f6f64cc43d1ae7bfc633452f36c086941abecbd8/eth/tracers/internal/tracetest/calltrace_test.go#L49