### PR TITLE
[PEPC-Boost][11] Implement custom devnet state interference checks

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -43,6 +43,15 @@ var (
 	ForkVersionStringBellatrix = "bellatrix"
 	ForkVersionStringCapella   = "capella"
 	ForkVersionStringDeneb     = "deneb"
+
+	// this is for storing DeFi addresses for state interference checks
+	DaiToken  = "dai"
+	WethToken = "weth"
+	// 2 addresses are specifically in custom devnet, we have 2 pairs of Dai/Weth for arbitrage tests
+	DaiWethPair1    = "dai_weth_pair_1"
+	DaiWethPair2    = "dai_weth_pair_2"
+	UniswapFactory1 = "uniswap_factory_1"
+	UniswapFactory2 = "uniswap_factory_2"
 )
 
 type EthNetworkDetails struct {

--- a/contracts/atomic-swap.go
+++ b/contracts/atomic-swap.go
@@ -1,0 +1,338 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package contracts
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// AtomicSwapMetaData contains all meta data concerning the AtomicSwap contract.
+var AtomicSwapMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_weth\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"stateMutability\":\"payable\",\"type\":\"fallback\"},{\"inputs\":[],\"name\":\"WETH\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_tokenArb\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_tokenSettle\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_startFactory\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_endFactory\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_pairStart\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_pairEnd\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amountIn\",\"type\":\"uint256\"}],\"name\":\"arb\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_startFactory\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_endFactory\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amountIn\",\"type\":\"uint256\"}],\"name\":\"backrun\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"liquidate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"factory\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"fromThis\",\"type\":\"bool\"}],\"name\":\"swap\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"factory\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_pair\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"fromThis\",\"type\":\"bool\"}],\"name\":\"swapCheaper\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// AtomicSwapABI is the input ABI used to generate the binding from.
+// Deprecated: Use AtomicSwapMetaData.ABI instead.
+var AtomicSwapABI = AtomicSwapMetaData.ABI
+
+// AtomicSwap is an auto generated Go binding around an Ethereum contract.
+type AtomicSwap struct {
+	AtomicSwapCaller     // Read-only binding to the contract
+	AtomicSwapTransactor // Write-only binding to the contract
+	AtomicSwapFilterer   // Log filterer for contract events
+}
+
+// AtomicSwapCaller is an auto generated read-only Go binding around an Ethereum contract.
+type AtomicSwapCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AtomicSwapTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type AtomicSwapTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AtomicSwapFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type AtomicSwapFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AtomicSwapSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type AtomicSwapSession struct {
+	Contract     *AtomicSwap       // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// AtomicSwapCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type AtomicSwapCallerSession struct {
+	Contract *AtomicSwapCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts     // Call options to use throughout this session
+}
+
+// AtomicSwapTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type AtomicSwapTransactorSession struct {
+	Contract     *AtomicSwapTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// AtomicSwapRaw is an auto generated low-level Go binding around an Ethereum contract.
+type AtomicSwapRaw struct {
+	Contract *AtomicSwap // Generic contract binding to access the raw methods on
+}
+
+// AtomicSwapCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type AtomicSwapCallerRaw struct {
+	Contract *AtomicSwapCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// AtomicSwapTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type AtomicSwapTransactorRaw struct {
+	Contract *AtomicSwapTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewAtomicSwap creates a new instance of AtomicSwap, bound to a specific deployed contract.
+func NewAtomicSwap(address common.Address, backend bind.ContractBackend) (*AtomicSwap, error) {
+	contract, err := bindAtomicSwap(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &AtomicSwap{AtomicSwapCaller: AtomicSwapCaller{contract: contract}, AtomicSwapTransactor: AtomicSwapTransactor{contract: contract}, AtomicSwapFilterer: AtomicSwapFilterer{contract: contract}}, nil
+}
+
+// NewAtomicSwapCaller creates a new read-only instance of AtomicSwap, bound to a specific deployed contract.
+func NewAtomicSwapCaller(address common.Address, caller bind.ContractCaller) (*AtomicSwapCaller, error) {
+	contract, err := bindAtomicSwap(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AtomicSwapCaller{contract: contract}, nil
+}
+
+// NewAtomicSwapTransactor creates a new write-only instance of AtomicSwap, bound to a specific deployed contract.
+func NewAtomicSwapTransactor(address common.Address, transactor bind.ContractTransactor) (*AtomicSwapTransactor, error) {
+	contract, err := bindAtomicSwap(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AtomicSwapTransactor{contract: contract}, nil
+}
+
+// NewAtomicSwapFilterer creates a new log filterer instance of AtomicSwap, bound to a specific deployed contract.
+func NewAtomicSwapFilterer(address common.Address, filterer bind.ContractFilterer) (*AtomicSwapFilterer, error) {
+	contract, err := bindAtomicSwap(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &AtomicSwapFilterer{contract: contract}, nil
+}
+
+// bindAtomicSwap binds a generic wrapper to an already deployed contract.
+func bindAtomicSwap(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := AtomicSwapMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_AtomicSwap *AtomicSwapRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _AtomicSwap.Contract.AtomicSwapCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_AtomicSwap *AtomicSwapRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.AtomicSwapTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_AtomicSwap *AtomicSwapRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.AtomicSwapTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_AtomicSwap *AtomicSwapCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _AtomicSwap.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_AtomicSwap *AtomicSwapTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_AtomicSwap *AtomicSwapTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.contract.Transact(opts, method, params...)
+}
+
+// WETH is a free data retrieval call binding the contract method 0xad5c4648.
+//
+// Solidity: function WETH() view returns(address)
+func (_AtomicSwap *AtomicSwapCaller) WETH(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _AtomicSwap.contract.Call(opts, &out, "WETH")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// WETH is a free data retrieval call binding the contract method 0xad5c4648.
+//
+// Solidity: function WETH() view returns(address)
+func (_AtomicSwap *AtomicSwapSession) WETH() (common.Address, error) {
+	return _AtomicSwap.Contract.WETH(&_AtomicSwap.CallOpts)
+}
+
+// WETH is a free data retrieval call binding the contract method 0xad5c4648.
+//
+// Solidity: function WETH() view returns(address)
+func (_AtomicSwap *AtomicSwapCallerSession) WETH() (common.Address, error) {
+	return _AtomicSwap.Contract.WETH(&_AtomicSwap.CallOpts)
+}
+
+// Arb is a paid mutator transaction binding the contract method 0x3437a611.
+//
+// Solidity: function arb(address _tokenArb, address _tokenSettle, address _startFactory, address _endFactory, address _pairStart, address _pairEnd, uint256 _amountIn) returns(uint256 amountOut)
+func (_AtomicSwap *AtomicSwapTransactor) Arb(opts *bind.TransactOpts, _tokenArb common.Address, _tokenSettle common.Address, _startFactory common.Address, _endFactory common.Address, _pairStart common.Address, _pairEnd common.Address, _amountIn *big.Int) (*types.Transaction, error) {
+	return _AtomicSwap.contract.Transact(opts, "arb", _tokenArb, _tokenSettle, _startFactory, _endFactory, _pairStart, _pairEnd, _amountIn)
+}
+
+// Arb is a paid mutator transaction binding the contract method 0x3437a611.
+//
+// Solidity: function arb(address _tokenArb, address _tokenSettle, address _startFactory, address _endFactory, address _pairStart, address _pairEnd, uint256 _amountIn) returns(uint256 amountOut)
+func (_AtomicSwap *AtomicSwapSession) Arb(_tokenArb common.Address, _tokenSettle common.Address, _startFactory common.Address, _endFactory common.Address, _pairStart common.Address, _pairEnd common.Address, _amountIn *big.Int) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.Arb(&_AtomicSwap.TransactOpts, _tokenArb, _tokenSettle, _startFactory, _endFactory, _pairStart, _pairEnd, _amountIn)
+}
+
+// Arb is a paid mutator transaction binding the contract method 0x3437a611.
+//
+// Solidity: function arb(address _tokenArb, address _tokenSettle, address _startFactory, address _endFactory, address _pairStart, address _pairEnd, uint256 _amountIn) returns(uint256 amountOut)
+func (_AtomicSwap *AtomicSwapTransactorSession) Arb(_tokenArb common.Address, _tokenSettle common.Address, _startFactory common.Address, _endFactory common.Address, _pairStart common.Address, _pairEnd common.Address, _amountIn *big.Int) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.Arb(&_AtomicSwap.TransactOpts, _tokenArb, _tokenSettle, _startFactory, _endFactory, _pairStart, _pairEnd, _amountIn)
+}
+
+// Backrun is a paid mutator transaction binding the contract method 0x86f89bd2.
+//
+// Solidity: function backrun(address _token, address _startFactory, address _endFactory, uint256 _amountIn) returns()
+func (_AtomicSwap *AtomicSwapTransactor) Backrun(opts *bind.TransactOpts, _token common.Address, _startFactory common.Address, _endFactory common.Address, _amountIn *big.Int) (*types.Transaction, error) {
+	return _AtomicSwap.contract.Transact(opts, "backrun", _token, _startFactory, _endFactory, _amountIn)
+}
+
+// Backrun is a paid mutator transaction binding the contract method 0x86f89bd2.
+//
+// Solidity: function backrun(address _token, address _startFactory, address _endFactory, uint256 _amountIn) returns()
+func (_AtomicSwap *AtomicSwapSession) Backrun(_token common.Address, _startFactory common.Address, _endFactory common.Address, _amountIn *big.Int) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.Backrun(&_AtomicSwap.TransactOpts, _token, _startFactory, _endFactory, _amountIn)
+}
+
+// Backrun is a paid mutator transaction binding the contract method 0x86f89bd2.
+//
+// Solidity: function backrun(address _token, address _startFactory, address _endFactory, uint256 _amountIn) returns()
+func (_AtomicSwap *AtomicSwapTransactorSession) Backrun(_token common.Address, _startFactory common.Address, _endFactory common.Address, _amountIn *big.Int) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.Backrun(&_AtomicSwap.TransactOpts, _token, _startFactory, _endFactory, _amountIn)
+}
+
+// Liquidate is a paid mutator transaction binding the contract method 0x28a07025.
+//
+// Solidity: function liquidate() returns()
+func (_AtomicSwap *AtomicSwapTransactor) Liquidate(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AtomicSwap.contract.Transact(opts, "liquidate")
+}
+
+// Liquidate is a paid mutator transaction binding the contract method 0x28a07025.
+//
+// Solidity: function liquidate() returns()
+func (_AtomicSwap *AtomicSwapSession) Liquidate() (*types.Transaction, error) {
+	return _AtomicSwap.Contract.Liquidate(&_AtomicSwap.TransactOpts)
+}
+
+// Liquidate is a paid mutator transaction binding the contract method 0x28a07025.
+//
+// Solidity: function liquidate() returns()
+func (_AtomicSwap *AtomicSwapTransactorSession) Liquidate() (*types.Transaction, error) {
+	return _AtomicSwap.Contract.Liquidate(&_AtomicSwap.TransactOpts)
+}
+
+// Swap is a paid mutator transaction binding the contract method 0x0cc73263.
+//
+// Solidity: function swap(address[] path, uint256 amountIn, address factory, address recipient, bool fromThis) returns()
+func (_AtomicSwap *AtomicSwapTransactor) Swap(opts *bind.TransactOpts, path []common.Address, amountIn *big.Int, factory common.Address, recipient common.Address, fromThis bool) (*types.Transaction, error) {
+	return _AtomicSwap.contract.Transact(opts, "swap", path, amountIn, factory, recipient, fromThis)
+}
+
+// Swap is a paid mutator transaction binding the contract method 0x0cc73263.
+//
+// Solidity: function swap(address[] path, uint256 amountIn, address factory, address recipient, bool fromThis) returns()
+func (_AtomicSwap *AtomicSwapSession) Swap(path []common.Address, amountIn *big.Int, factory common.Address, recipient common.Address, fromThis bool) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.Swap(&_AtomicSwap.TransactOpts, path, amountIn, factory, recipient, fromThis)
+}
+
+// Swap is a paid mutator transaction binding the contract method 0x0cc73263.
+//
+// Solidity: function swap(address[] path, uint256 amountIn, address factory, address recipient, bool fromThis) returns()
+func (_AtomicSwap *AtomicSwapTransactorSession) Swap(path []common.Address, amountIn *big.Int, factory common.Address, recipient common.Address, fromThis bool) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.Swap(&_AtomicSwap.TransactOpts, path, amountIn, factory, recipient, fromThis)
+}
+
+// SwapCheaper is a paid mutator transaction binding the contract method 0x7e372601.
+//
+// Solidity: function swapCheaper(address[] path, uint256 amountIn, address factory, address recipient, address _pair, bool fromThis) returns(uint256 amountOut)
+func (_AtomicSwap *AtomicSwapTransactor) SwapCheaper(opts *bind.TransactOpts, path []common.Address, amountIn *big.Int, factory common.Address, recipient common.Address, _pair common.Address, fromThis bool) (*types.Transaction, error) {
+	return _AtomicSwap.contract.Transact(opts, "swapCheaper", path, amountIn, factory, recipient, _pair, fromThis)
+}
+
+// SwapCheaper is a paid mutator transaction binding the contract method 0x7e372601.
+//
+// Solidity: function swapCheaper(address[] path, uint256 amountIn, address factory, address recipient, address _pair, bool fromThis) returns(uint256 amountOut)
+func (_AtomicSwap *AtomicSwapSession) SwapCheaper(path []common.Address, amountIn *big.Int, factory common.Address, recipient common.Address, _pair common.Address, fromThis bool) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.SwapCheaper(&_AtomicSwap.TransactOpts, path, amountIn, factory, recipient, _pair, fromThis)
+}
+
+// SwapCheaper is a paid mutator transaction binding the contract method 0x7e372601.
+//
+// Solidity: function swapCheaper(address[] path, uint256 amountIn, address factory, address recipient, address _pair, bool fromThis) returns(uint256 amountOut)
+func (_AtomicSwap *AtomicSwapTransactorSession) SwapCheaper(path []common.Address, amountIn *big.Int, factory common.Address, recipient common.Address, _pair common.Address, fromThis bool) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.SwapCheaper(&_AtomicSwap.TransactOpts, path, amountIn, factory, recipient, _pair, fromThis)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_AtomicSwap *AtomicSwapTransactor) Fallback(opts *bind.TransactOpts, calldata []byte) (*types.Transaction, error) {
+	return _AtomicSwap.contract.RawTransact(opts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_AtomicSwap *AtomicSwapSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.Fallback(&_AtomicSwap.TransactOpts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_AtomicSwap *AtomicSwapTransactorSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _AtomicSwap.Contract.Fallback(&_AtomicSwap.TransactOpts, calldata)
+}

--- a/contracts/uniswap-pair.go
+++ b/contracts/uniswap-pair.go
@@ -1,0 +1,1842 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package contracts
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// UniswapPairMetaData contains all meta data concerning the UniswapPair contract.
+var UniswapPairMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount0\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount1\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"Burn\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount0\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount1\",\"type\":\"uint256\"}],\"name\":\"Mint\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount0In\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount1In\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount0Out\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount1Out\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"Swap\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint112\",\"name\":\"reserve0\",\"type\":\"uint112\"},{\"indexed\":false,\"internalType\":\"uint112\",\"name\":\"reserve1\",\"type\":\"uint112\"}],\"name\":\"Sync\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"constant\":true,\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"MINIMUM_LIQUIDITY\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"PERMIT_TYPEHASH\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"burn\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amount0\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount1\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"factory\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getReserves\",\"outputs\":[{\"internalType\":\"uint112\",\"name\":\"_reserve0\",\"type\":\"uint112\"},{\"internalType\":\"uint112\",\"name\":\"_reserve1\",\"type\":\"uint112\"},{\"internalType\":\"uint32\",\"name\":\"_blockTimestampLast\",\"type\":\"uint32\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"_token0\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_token1\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"kLast\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"mint\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"liquidity\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"price0CumulativeLast\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"price1CumulativeLast\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"skim\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amount0Out\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount1Out\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"swap\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"sync\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"token0\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"token1\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// UniswapPairABI is the input ABI used to generate the binding from.
+// Deprecated: Use UniswapPairMetaData.ABI instead.
+var UniswapPairABI = UniswapPairMetaData.ABI
+
+// UniswapPair is an auto generated Go binding around an Ethereum contract.
+type UniswapPair struct {
+	UniswapPairCaller     // Read-only binding to the contract
+	UniswapPairTransactor // Write-only binding to the contract
+	UniswapPairFilterer   // Log filterer for contract events
+}
+
+// UniswapPairCaller is an auto generated read-only Go binding around an Ethereum contract.
+type UniswapPairCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniswapPairTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type UniswapPairTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniswapPairFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type UniswapPairFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniswapPairSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type UniswapPairSession struct {
+	Contract     *UniswapPair      // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// UniswapPairCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type UniswapPairCallerSession struct {
+	Contract *UniswapPairCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts      // Call options to use throughout this session
+}
+
+// UniswapPairTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type UniswapPairTransactorSession struct {
+	Contract     *UniswapPairTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// UniswapPairRaw is an auto generated low-level Go binding around an Ethereum contract.
+type UniswapPairRaw struct {
+	Contract *UniswapPair // Generic contract binding to access the raw methods on
+}
+
+// UniswapPairCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type UniswapPairCallerRaw struct {
+	Contract *UniswapPairCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// UniswapPairTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type UniswapPairTransactorRaw struct {
+	Contract *UniswapPairTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewUniswapPair creates a new instance of UniswapPair, bound to a specific deployed contract.
+func NewUniswapPair(address common.Address, backend bind.ContractBackend) (*UniswapPair, error) {
+	contract, err := bindUniswapPair(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapPair{UniswapPairCaller: UniswapPairCaller{contract: contract}, UniswapPairTransactor: UniswapPairTransactor{contract: contract}, UniswapPairFilterer: UniswapPairFilterer{contract: contract}}, nil
+}
+
+// NewUniswapPairCaller creates a new read-only instance of UniswapPair, bound to a specific deployed contract.
+func NewUniswapPairCaller(address common.Address, caller bind.ContractCaller) (*UniswapPairCaller, error) {
+	contract, err := bindUniswapPair(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapPairCaller{contract: contract}, nil
+}
+
+// NewUniswapPairTransactor creates a new write-only instance of UniswapPair, bound to a specific deployed contract.
+func NewUniswapPairTransactor(address common.Address, transactor bind.ContractTransactor) (*UniswapPairTransactor, error) {
+	contract, err := bindUniswapPair(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapPairTransactor{contract: contract}, nil
+}
+
+// NewUniswapPairFilterer creates a new log filterer instance of UniswapPair, bound to a specific deployed contract.
+func NewUniswapPairFilterer(address common.Address, filterer bind.ContractFilterer) (*UniswapPairFilterer, error) {
+	contract, err := bindUniswapPair(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapPairFilterer{contract: contract}, nil
+}
+
+// bindUniswapPair binds a generic wrapper to an already deployed contract.
+func bindUniswapPair(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := UniswapPairMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_UniswapPair *UniswapPairRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _UniswapPair.Contract.UniswapPairCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_UniswapPair *UniswapPairRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniswapPair.Contract.UniswapPairTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_UniswapPair *UniswapPairRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _UniswapPair.Contract.UniswapPairTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_UniswapPair *UniswapPairCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _UniswapPair.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_UniswapPair *UniswapPairTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniswapPair.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_UniswapPair *UniswapPairTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _UniswapPair.Contract.contract.Transact(opts, method, params...)
+}
+
+// DOMAINSEPARATOR is a free data retrieval call binding the contract method 0x3644e515.
+//
+// Solidity: function DOMAIN_SEPARATOR() view returns(bytes32)
+func (_UniswapPair *UniswapPairCaller) DOMAINSEPARATOR(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "DOMAIN_SEPARATOR")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DOMAINSEPARATOR is a free data retrieval call binding the contract method 0x3644e515.
+//
+// Solidity: function DOMAIN_SEPARATOR() view returns(bytes32)
+func (_UniswapPair *UniswapPairSession) DOMAINSEPARATOR() ([32]byte, error) {
+	return _UniswapPair.Contract.DOMAINSEPARATOR(&_UniswapPair.CallOpts)
+}
+
+// DOMAINSEPARATOR is a free data retrieval call binding the contract method 0x3644e515.
+//
+// Solidity: function DOMAIN_SEPARATOR() view returns(bytes32)
+func (_UniswapPair *UniswapPairCallerSession) DOMAINSEPARATOR() ([32]byte, error) {
+	return _UniswapPair.Contract.DOMAINSEPARATOR(&_UniswapPair.CallOpts)
+}
+
+// MINIMUMLIQUIDITY is a free data retrieval call binding the contract method 0xba9a7a56.
+//
+// Solidity: function MINIMUM_LIQUIDITY() view returns(uint256)
+func (_UniswapPair *UniswapPairCaller) MINIMUMLIQUIDITY(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "MINIMUM_LIQUIDITY")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MINIMUMLIQUIDITY is a free data retrieval call binding the contract method 0xba9a7a56.
+//
+// Solidity: function MINIMUM_LIQUIDITY() view returns(uint256)
+func (_UniswapPair *UniswapPairSession) MINIMUMLIQUIDITY() (*big.Int, error) {
+	return _UniswapPair.Contract.MINIMUMLIQUIDITY(&_UniswapPair.CallOpts)
+}
+
+// MINIMUMLIQUIDITY is a free data retrieval call binding the contract method 0xba9a7a56.
+//
+// Solidity: function MINIMUM_LIQUIDITY() view returns(uint256)
+func (_UniswapPair *UniswapPairCallerSession) MINIMUMLIQUIDITY() (*big.Int, error) {
+	return _UniswapPair.Contract.MINIMUMLIQUIDITY(&_UniswapPair.CallOpts)
+}
+
+// PERMITTYPEHASH is a free data retrieval call binding the contract method 0x30adf81f.
+//
+// Solidity: function PERMIT_TYPEHASH() view returns(bytes32)
+func (_UniswapPair *UniswapPairCaller) PERMITTYPEHASH(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "PERMIT_TYPEHASH")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// PERMITTYPEHASH is a free data retrieval call binding the contract method 0x30adf81f.
+//
+// Solidity: function PERMIT_TYPEHASH() view returns(bytes32)
+func (_UniswapPair *UniswapPairSession) PERMITTYPEHASH() ([32]byte, error) {
+	return _UniswapPair.Contract.PERMITTYPEHASH(&_UniswapPair.CallOpts)
+}
+
+// PERMITTYPEHASH is a free data retrieval call binding the contract method 0x30adf81f.
+//
+// Solidity: function PERMIT_TYPEHASH() view returns(bytes32)
+func (_UniswapPair *UniswapPairCallerSession) PERMITTYPEHASH() ([32]byte, error) {
+	return _UniswapPair.Contract.PERMITTYPEHASH(&_UniswapPair.CallOpts)
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address , address ) view returns(uint256)
+func (_UniswapPair *UniswapPairCaller) Allowance(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "allowance", arg0, arg1)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address , address ) view returns(uint256)
+func (_UniswapPair *UniswapPairSession) Allowance(arg0 common.Address, arg1 common.Address) (*big.Int, error) {
+	return _UniswapPair.Contract.Allowance(&_UniswapPair.CallOpts, arg0, arg1)
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address , address ) view returns(uint256)
+func (_UniswapPair *UniswapPairCallerSession) Allowance(arg0 common.Address, arg1 common.Address) (*big.Int, error) {
+	return _UniswapPair.Contract.Allowance(&_UniswapPair.CallOpts, arg0, arg1)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address ) view returns(uint256)
+func (_UniswapPair *UniswapPairCaller) BalanceOf(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "balanceOf", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address ) view returns(uint256)
+func (_UniswapPair *UniswapPairSession) BalanceOf(arg0 common.Address) (*big.Int, error) {
+	return _UniswapPair.Contract.BalanceOf(&_UniswapPair.CallOpts, arg0)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address ) view returns(uint256)
+func (_UniswapPair *UniswapPairCallerSession) BalanceOf(arg0 common.Address) (*big.Int, error) {
+	return _UniswapPair.Contract.BalanceOf(&_UniswapPair.CallOpts, arg0)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_UniswapPair *UniswapPairCaller) Decimals(opts *bind.CallOpts) (uint8, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "decimals")
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_UniswapPair *UniswapPairSession) Decimals() (uint8, error) {
+	return _UniswapPair.Contract.Decimals(&_UniswapPair.CallOpts)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_UniswapPair *UniswapPairCallerSession) Decimals() (uint8, error) {
+	return _UniswapPair.Contract.Decimals(&_UniswapPair.CallOpts)
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniswapPair *UniswapPairCaller) Factory(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "factory")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniswapPair *UniswapPairSession) Factory() (common.Address, error) {
+	return _UniswapPair.Contract.Factory(&_UniswapPair.CallOpts)
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniswapPair *UniswapPairCallerSession) Factory() (common.Address, error) {
+	return _UniswapPair.Contract.Factory(&_UniswapPair.CallOpts)
+}
+
+// GetReserves is a free data retrieval call binding the contract method 0x0902f1ac.
+//
+// Solidity: function getReserves() view returns(uint112 _reserve0, uint112 _reserve1, uint32 _blockTimestampLast)
+func (_UniswapPair *UniswapPairCaller) GetReserves(opts *bind.CallOpts) (struct {
+	Reserve0           *big.Int
+	Reserve1           *big.Int
+	BlockTimestampLast uint32
+}, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "getReserves")
+
+	outstruct := new(struct {
+		Reserve0           *big.Int
+		Reserve1           *big.Int
+		BlockTimestampLast uint32
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Reserve0 = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Reserve1 = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.BlockTimestampLast = *abi.ConvertType(out[2], new(uint32)).(*uint32)
+
+	return *outstruct, err
+
+}
+
+// GetReserves is a free data retrieval call binding the contract method 0x0902f1ac.
+//
+// Solidity: function getReserves() view returns(uint112 _reserve0, uint112 _reserve1, uint32 _blockTimestampLast)
+func (_UniswapPair *UniswapPairSession) GetReserves() (struct {
+	Reserve0           *big.Int
+	Reserve1           *big.Int
+	BlockTimestampLast uint32
+}, error) {
+	return _UniswapPair.Contract.GetReserves(&_UniswapPair.CallOpts)
+}
+
+// GetReserves is a free data retrieval call binding the contract method 0x0902f1ac.
+//
+// Solidity: function getReserves() view returns(uint112 _reserve0, uint112 _reserve1, uint32 _blockTimestampLast)
+func (_UniswapPair *UniswapPairCallerSession) GetReserves() (struct {
+	Reserve0           *big.Int
+	Reserve1           *big.Int
+	BlockTimestampLast uint32
+}, error) {
+	return _UniswapPair.Contract.GetReserves(&_UniswapPair.CallOpts)
+}
+
+// KLast is a free data retrieval call binding the contract method 0x7464fc3d.
+//
+// Solidity: function kLast() view returns(uint256)
+func (_UniswapPair *UniswapPairCaller) KLast(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "kLast")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// KLast is a free data retrieval call binding the contract method 0x7464fc3d.
+//
+// Solidity: function kLast() view returns(uint256)
+func (_UniswapPair *UniswapPairSession) KLast() (*big.Int, error) {
+	return _UniswapPair.Contract.KLast(&_UniswapPair.CallOpts)
+}
+
+// KLast is a free data retrieval call binding the contract method 0x7464fc3d.
+//
+// Solidity: function kLast() view returns(uint256)
+func (_UniswapPair *UniswapPairCallerSession) KLast() (*big.Int, error) {
+	return _UniswapPair.Contract.KLast(&_UniswapPair.CallOpts)
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_UniswapPair *UniswapPairCaller) Name(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "name")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_UniswapPair *UniswapPairSession) Name() (string, error) {
+	return _UniswapPair.Contract.Name(&_UniswapPair.CallOpts)
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_UniswapPair *UniswapPairCallerSession) Name() (string, error) {
+	return _UniswapPair.Contract.Name(&_UniswapPair.CallOpts)
+}
+
+// Nonces is a free data retrieval call binding the contract method 0x7ecebe00.
+//
+// Solidity: function nonces(address ) view returns(uint256)
+func (_UniswapPair *UniswapPairCaller) Nonces(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "nonces", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Nonces is a free data retrieval call binding the contract method 0x7ecebe00.
+//
+// Solidity: function nonces(address ) view returns(uint256)
+func (_UniswapPair *UniswapPairSession) Nonces(arg0 common.Address) (*big.Int, error) {
+	return _UniswapPair.Contract.Nonces(&_UniswapPair.CallOpts, arg0)
+}
+
+// Nonces is a free data retrieval call binding the contract method 0x7ecebe00.
+//
+// Solidity: function nonces(address ) view returns(uint256)
+func (_UniswapPair *UniswapPairCallerSession) Nonces(arg0 common.Address) (*big.Int, error) {
+	return _UniswapPair.Contract.Nonces(&_UniswapPair.CallOpts, arg0)
+}
+
+// Price0CumulativeLast is a free data retrieval call binding the contract method 0x5909c0d5.
+//
+// Solidity: function price0CumulativeLast() view returns(uint256)
+func (_UniswapPair *UniswapPairCaller) Price0CumulativeLast(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "price0CumulativeLast")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Price0CumulativeLast is a free data retrieval call binding the contract method 0x5909c0d5.
+//
+// Solidity: function price0CumulativeLast() view returns(uint256)
+func (_UniswapPair *UniswapPairSession) Price0CumulativeLast() (*big.Int, error) {
+	return _UniswapPair.Contract.Price0CumulativeLast(&_UniswapPair.CallOpts)
+}
+
+// Price0CumulativeLast is a free data retrieval call binding the contract method 0x5909c0d5.
+//
+// Solidity: function price0CumulativeLast() view returns(uint256)
+func (_UniswapPair *UniswapPairCallerSession) Price0CumulativeLast() (*big.Int, error) {
+	return _UniswapPair.Contract.Price0CumulativeLast(&_UniswapPair.CallOpts)
+}
+
+// Price1CumulativeLast is a free data retrieval call binding the contract method 0x5a3d5493.
+//
+// Solidity: function price1CumulativeLast() view returns(uint256)
+func (_UniswapPair *UniswapPairCaller) Price1CumulativeLast(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "price1CumulativeLast")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Price1CumulativeLast is a free data retrieval call binding the contract method 0x5a3d5493.
+//
+// Solidity: function price1CumulativeLast() view returns(uint256)
+func (_UniswapPair *UniswapPairSession) Price1CumulativeLast() (*big.Int, error) {
+	return _UniswapPair.Contract.Price1CumulativeLast(&_UniswapPair.CallOpts)
+}
+
+// Price1CumulativeLast is a free data retrieval call binding the contract method 0x5a3d5493.
+//
+// Solidity: function price1CumulativeLast() view returns(uint256)
+func (_UniswapPair *UniswapPairCallerSession) Price1CumulativeLast() (*big.Int, error) {
+	return _UniswapPair.Contract.Price1CumulativeLast(&_UniswapPair.CallOpts)
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_UniswapPair *UniswapPairCaller) Symbol(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "symbol")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_UniswapPair *UniswapPairSession) Symbol() (string, error) {
+	return _UniswapPair.Contract.Symbol(&_UniswapPair.CallOpts)
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_UniswapPair *UniswapPairCallerSession) Symbol() (string, error) {
+	return _UniswapPair.Contract.Symbol(&_UniswapPair.CallOpts)
+}
+
+// Token0 is a free data retrieval call binding the contract method 0x0dfe1681.
+//
+// Solidity: function token0() view returns(address)
+func (_UniswapPair *UniswapPairCaller) Token0(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "token0")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Token0 is a free data retrieval call binding the contract method 0x0dfe1681.
+//
+// Solidity: function token0() view returns(address)
+func (_UniswapPair *UniswapPairSession) Token0() (common.Address, error) {
+	return _UniswapPair.Contract.Token0(&_UniswapPair.CallOpts)
+}
+
+// Token0 is a free data retrieval call binding the contract method 0x0dfe1681.
+//
+// Solidity: function token0() view returns(address)
+func (_UniswapPair *UniswapPairCallerSession) Token0() (common.Address, error) {
+	return _UniswapPair.Contract.Token0(&_UniswapPair.CallOpts)
+}
+
+// Token1 is a free data retrieval call binding the contract method 0xd21220a7.
+//
+// Solidity: function token1() view returns(address)
+func (_UniswapPair *UniswapPairCaller) Token1(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "token1")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Token1 is a free data retrieval call binding the contract method 0xd21220a7.
+//
+// Solidity: function token1() view returns(address)
+func (_UniswapPair *UniswapPairSession) Token1() (common.Address, error) {
+	return _UniswapPair.Contract.Token1(&_UniswapPair.CallOpts)
+}
+
+// Token1 is a free data retrieval call binding the contract method 0xd21220a7.
+//
+// Solidity: function token1() view returns(address)
+func (_UniswapPair *UniswapPairCallerSession) Token1() (common.Address, error) {
+	return _UniswapPair.Contract.Token1(&_UniswapPair.CallOpts)
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_UniswapPair *UniswapPairCaller) TotalSupply(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _UniswapPair.contract.Call(opts, &out, "totalSupply")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_UniswapPair *UniswapPairSession) TotalSupply() (*big.Int, error) {
+	return _UniswapPair.Contract.TotalSupply(&_UniswapPair.CallOpts)
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_UniswapPair *UniswapPairCallerSession) TotalSupply() (*big.Int, error) {
+	return _UniswapPair.Contract.TotalSupply(&_UniswapPair.CallOpts)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 value) returns(bool)
+func (_UniswapPair *UniswapPairTransactor) Approve(opts *bind.TransactOpts, spender common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniswapPair.contract.Transact(opts, "approve", spender, value)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 value) returns(bool)
+func (_UniswapPair *UniswapPairSession) Approve(spender common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Approve(&_UniswapPair.TransactOpts, spender, value)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 value) returns(bool)
+func (_UniswapPair *UniswapPairTransactorSession) Approve(spender common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Approve(&_UniswapPair.TransactOpts, spender, value)
+}
+
+// Burn is a paid mutator transaction binding the contract method 0x89afcb44.
+//
+// Solidity: function burn(address to) returns(uint256 amount0, uint256 amount1)
+func (_UniswapPair *UniswapPairTransactor) Burn(opts *bind.TransactOpts, to common.Address) (*types.Transaction, error) {
+	return _UniswapPair.contract.Transact(opts, "burn", to)
+}
+
+// Burn is a paid mutator transaction binding the contract method 0x89afcb44.
+//
+// Solidity: function burn(address to) returns(uint256 amount0, uint256 amount1)
+func (_UniswapPair *UniswapPairSession) Burn(to common.Address) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Burn(&_UniswapPair.TransactOpts, to)
+}
+
+// Burn is a paid mutator transaction binding the contract method 0x89afcb44.
+//
+// Solidity: function burn(address to) returns(uint256 amount0, uint256 amount1)
+func (_UniswapPair *UniswapPairTransactorSession) Burn(to common.Address) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Burn(&_UniswapPair.TransactOpts, to)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x485cc955.
+//
+// Solidity: function initialize(address _token0, address _token1) returns()
+func (_UniswapPair *UniswapPairTransactor) Initialize(opts *bind.TransactOpts, _token0 common.Address, _token1 common.Address) (*types.Transaction, error) {
+	return _UniswapPair.contract.Transact(opts, "initialize", _token0, _token1)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x485cc955.
+//
+// Solidity: function initialize(address _token0, address _token1) returns()
+func (_UniswapPair *UniswapPairSession) Initialize(_token0 common.Address, _token1 common.Address) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Initialize(&_UniswapPair.TransactOpts, _token0, _token1)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x485cc955.
+//
+// Solidity: function initialize(address _token0, address _token1) returns()
+func (_UniswapPair *UniswapPairTransactorSession) Initialize(_token0 common.Address, _token1 common.Address) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Initialize(&_UniswapPair.TransactOpts, _token0, _token1)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x6a627842.
+//
+// Solidity: function mint(address to) returns(uint256 liquidity)
+func (_UniswapPair *UniswapPairTransactor) Mint(opts *bind.TransactOpts, to common.Address) (*types.Transaction, error) {
+	return _UniswapPair.contract.Transact(opts, "mint", to)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x6a627842.
+//
+// Solidity: function mint(address to) returns(uint256 liquidity)
+func (_UniswapPair *UniswapPairSession) Mint(to common.Address) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Mint(&_UniswapPair.TransactOpts, to)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x6a627842.
+//
+// Solidity: function mint(address to) returns(uint256 liquidity)
+func (_UniswapPair *UniswapPairTransactorSession) Mint(to common.Address) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Mint(&_UniswapPair.TransactOpts, to)
+}
+
+// Permit is a paid mutator transaction binding the contract method 0xd505accf.
+//
+// Solidity: function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) returns()
+func (_UniswapPair *UniswapPairTransactor) Permit(opts *bind.TransactOpts, owner common.Address, spender common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapPair.contract.Transact(opts, "permit", owner, spender, value, deadline, v, r, s)
+}
+
+// Permit is a paid mutator transaction binding the contract method 0xd505accf.
+//
+// Solidity: function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) returns()
+func (_UniswapPair *UniswapPairSession) Permit(owner common.Address, spender common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Permit(&_UniswapPair.TransactOpts, owner, spender, value, deadline, v, r, s)
+}
+
+// Permit is a paid mutator transaction binding the contract method 0xd505accf.
+//
+// Solidity: function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) returns()
+func (_UniswapPair *UniswapPairTransactorSession) Permit(owner common.Address, spender common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Permit(&_UniswapPair.TransactOpts, owner, spender, value, deadline, v, r, s)
+}
+
+// Skim is a paid mutator transaction binding the contract method 0xbc25cf77.
+//
+// Solidity: function skim(address to) returns()
+func (_UniswapPair *UniswapPairTransactor) Skim(opts *bind.TransactOpts, to common.Address) (*types.Transaction, error) {
+	return _UniswapPair.contract.Transact(opts, "skim", to)
+}
+
+// Skim is a paid mutator transaction binding the contract method 0xbc25cf77.
+//
+// Solidity: function skim(address to) returns()
+func (_UniswapPair *UniswapPairSession) Skim(to common.Address) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Skim(&_UniswapPair.TransactOpts, to)
+}
+
+// Skim is a paid mutator transaction binding the contract method 0xbc25cf77.
+//
+// Solidity: function skim(address to) returns()
+func (_UniswapPair *UniswapPairTransactorSession) Skim(to common.Address) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Skim(&_UniswapPair.TransactOpts, to)
+}
+
+// Swap is a paid mutator transaction binding the contract method 0x022c0d9f.
+//
+// Solidity: function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes data) returns()
+func (_UniswapPair *UniswapPairTransactor) Swap(opts *bind.TransactOpts, amount0Out *big.Int, amount1Out *big.Int, to common.Address, data []byte) (*types.Transaction, error) {
+	return _UniswapPair.contract.Transact(opts, "swap", amount0Out, amount1Out, to, data)
+}
+
+// Swap is a paid mutator transaction binding the contract method 0x022c0d9f.
+//
+// Solidity: function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes data) returns()
+func (_UniswapPair *UniswapPairSession) Swap(amount0Out *big.Int, amount1Out *big.Int, to common.Address, data []byte) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Swap(&_UniswapPair.TransactOpts, amount0Out, amount1Out, to, data)
+}
+
+// Swap is a paid mutator transaction binding the contract method 0x022c0d9f.
+//
+// Solidity: function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes data) returns()
+func (_UniswapPair *UniswapPairTransactorSession) Swap(amount0Out *big.Int, amount1Out *big.Int, to common.Address, data []byte) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Swap(&_UniswapPair.TransactOpts, amount0Out, amount1Out, to, data)
+}
+
+// Sync is a paid mutator transaction binding the contract method 0xfff6cae9.
+//
+// Solidity: function sync() returns()
+func (_UniswapPair *UniswapPairTransactor) Sync(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniswapPair.contract.Transact(opts, "sync")
+}
+
+// Sync is a paid mutator transaction binding the contract method 0xfff6cae9.
+//
+// Solidity: function sync() returns()
+func (_UniswapPair *UniswapPairSession) Sync() (*types.Transaction, error) {
+	return _UniswapPair.Contract.Sync(&_UniswapPair.TransactOpts)
+}
+
+// Sync is a paid mutator transaction binding the contract method 0xfff6cae9.
+//
+// Solidity: function sync() returns()
+func (_UniswapPair *UniswapPairTransactorSession) Sync() (*types.Transaction, error) {
+	return _UniswapPair.Contract.Sync(&_UniswapPair.TransactOpts)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 value) returns(bool)
+func (_UniswapPair *UniswapPairTransactor) Transfer(opts *bind.TransactOpts, to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniswapPair.contract.Transact(opts, "transfer", to, value)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 value) returns(bool)
+func (_UniswapPair *UniswapPairSession) Transfer(to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Transfer(&_UniswapPair.TransactOpts, to, value)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 value) returns(bool)
+func (_UniswapPair *UniswapPairTransactorSession) Transfer(to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniswapPair.Contract.Transfer(&_UniswapPair.TransactOpts, to, value)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address from, address to, uint256 value) returns(bool)
+func (_UniswapPair *UniswapPairTransactor) TransferFrom(opts *bind.TransactOpts, from common.Address, to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniswapPair.contract.Transact(opts, "transferFrom", from, to, value)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address from, address to, uint256 value) returns(bool)
+func (_UniswapPair *UniswapPairSession) TransferFrom(from common.Address, to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniswapPair.Contract.TransferFrom(&_UniswapPair.TransactOpts, from, to, value)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address from, address to, uint256 value) returns(bool)
+func (_UniswapPair *UniswapPairTransactorSession) TransferFrom(from common.Address, to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniswapPair.Contract.TransferFrom(&_UniswapPair.TransactOpts, from, to, value)
+}
+
+// UniswapPairApprovalIterator is returned from FilterApproval and is used to iterate over the raw logs and unpacked data for Approval events raised by the UniswapPair contract.
+type UniswapPairApprovalIterator struct {
+	Event *UniswapPairApproval // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *UniswapPairApprovalIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(UniswapPairApproval)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(UniswapPairApproval)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *UniswapPairApprovalIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *UniswapPairApprovalIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// UniswapPairApproval represents a Approval event raised by the UniswapPair contract.
+type UniswapPairApproval struct {
+	Owner   common.Address
+	Spender common.Address
+	Value   *big.Int
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterApproval is a free log retrieval operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_UniswapPair *UniswapPairFilterer) FilterApproval(opts *bind.FilterOpts, owner []common.Address, spender []common.Address) (*UniswapPairApprovalIterator, error) {
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+	var spenderRule []interface{}
+	for _, spenderItem := range spender {
+		spenderRule = append(spenderRule, spenderItem)
+	}
+
+	logs, sub, err := _UniswapPair.contract.FilterLogs(opts, "Approval", ownerRule, spenderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapPairApprovalIterator{contract: _UniswapPair.contract, event: "Approval", logs: logs, sub: sub}, nil
+}
+
+// WatchApproval is a free log subscription operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_UniswapPair *UniswapPairFilterer) WatchApproval(opts *bind.WatchOpts, sink chan<- *UniswapPairApproval, owner []common.Address, spender []common.Address) (event.Subscription, error) {
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+	var spenderRule []interface{}
+	for _, spenderItem := range spender {
+		spenderRule = append(spenderRule, spenderItem)
+	}
+
+	logs, sub, err := _UniswapPair.contract.WatchLogs(opts, "Approval", ownerRule, spenderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(UniswapPairApproval)
+				if err := _UniswapPair.contract.UnpackLog(event, "Approval", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseApproval is a log parse operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_UniswapPair *UniswapPairFilterer) ParseApproval(log types.Log) (*UniswapPairApproval, error) {
+	event := new(UniswapPairApproval)
+	if err := _UniswapPair.contract.UnpackLog(event, "Approval", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// UniswapPairBurnIterator is returned from FilterBurn and is used to iterate over the raw logs and unpacked data for Burn events raised by the UniswapPair contract.
+type UniswapPairBurnIterator struct {
+	Event *UniswapPairBurn // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *UniswapPairBurnIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(UniswapPairBurn)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(UniswapPairBurn)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *UniswapPairBurnIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *UniswapPairBurnIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// UniswapPairBurn represents a Burn event raised by the UniswapPair contract.
+type UniswapPairBurn struct {
+	Sender  common.Address
+	Amount0 *big.Int
+	Amount1 *big.Int
+	To      common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterBurn is a free log retrieval operation binding the contract event 0xdccd412f0b1252819cb1fd330b93224ca42612892bb3f4f789976e6d81936496.
+//
+// Solidity: event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to)
+func (_UniswapPair *UniswapPairFilterer) FilterBurn(opts *bind.FilterOpts, sender []common.Address, to []common.Address) (*UniswapPairBurnIterator, error) {
+
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _UniswapPair.contract.FilterLogs(opts, "Burn", senderRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapPairBurnIterator{contract: _UniswapPair.contract, event: "Burn", logs: logs, sub: sub}, nil
+}
+
+// WatchBurn is a free log subscription operation binding the contract event 0xdccd412f0b1252819cb1fd330b93224ca42612892bb3f4f789976e6d81936496.
+//
+// Solidity: event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to)
+func (_UniswapPair *UniswapPairFilterer) WatchBurn(opts *bind.WatchOpts, sink chan<- *UniswapPairBurn, sender []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _UniswapPair.contract.WatchLogs(opts, "Burn", senderRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(UniswapPairBurn)
+				if err := _UniswapPair.contract.UnpackLog(event, "Burn", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBurn is a log parse operation binding the contract event 0xdccd412f0b1252819cb1fd330b93224ca42612892bb3f4f789976e6d81936496.
+//
+// Solidity: event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to)
+func (_UniswapPair *UniswapPairFilterer) ParseBurn(log types.Log) (*UniswapPairBurn, error) {
+	event := new(UniswapPairBurn)
+	if err := _UniswapPair.contract.UnpackLog(event, "Burn", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// UniswapPairMintIterator is returned from FilterMint and is used to iterate over the raw logs and unpacked data for Mint events raised by the UniswapPair contract.
+type UniswapPairMintIterator struct {
+	Event *UniswapPairMint // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *UniswapPairMintIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(UniswapPairMint)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(UniswapPairMint)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *UniswapPairMintIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *UniswapPairMintIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// UniswapPairMint represents a Mint event raised by the UniswapPair contract.
+type UniswapPairMint struct {
+	Sender  common.Address
+	Amount0 *big.Int
+	Amount1 *big.Int
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterMint is a free log retrieval operation binding the contract event 0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f.
+//
+// Solidity: event Mint(address indexed sender, uint256 amount0, uint256 amount1)
+func (_UniswapPair *UniswapPairFilterer) FilterMint(opts *bind.FilterOpts, sender []common.Address) (*UniswapPairMintIterator, error) {
+
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _UniswapPair.contract.FilterLogs(opts, "Mint", senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapPairMintIterator{contract: _UniswapPair.contract, event: "Mint", logs: logs, sub: sub}, nil
+}
+
+// WatchMint is a free log subscription operation binding the contract event 0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f.
+//
+// Solidity: event Mint(address indexed sender, uint256 amount0, uint256 amount1)
+func (_UniswapPair *UniswapPairFilterer) WatchMint(opts *bind.WatchOpts, sink chan<- *UniswapPairMint, sender []common.Address) (event.Subscription, error) {
+
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _UniswapPair.contract.WatchLogs(opts, "Mint", senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(UniswapPairMint)
+				if err := _UniswapPair.contract.UnpackLog(event, "Mint", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMint is a log parse operation binding the contract event 0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f.
+//
+// Solidity: event Mint(address indexed sender, uint256 amount0, uint256 amount1)
+func (_UniswapPair *UniswapPairFilterer) ParseMint(log types.Log) (*UniswapPairMint, error) {
+	event := new(UniswapPairMint)
+	if err := _UniswapPair.contract.UnpackLog(event, "Mint", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// UniswapPairSwapIterator is returned from FilterSwap and is used to iterate over the raw logs and unpacked data for Swap events raised by the UniswapPair contract.
+type UniswapPairSwapIterator struct {
+	Event *UniswapPairSwap // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *UniswapPairSwapIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(UniswapPairSwap)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(UniswapPairSwap)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *UniswapPairSwapIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *UniswapPairSwapIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// UniswapPairSwap represents a Swap event raised by the UniswapPair contract.
+type UniswapPairSwap struct {
+	Sender     common.Address
+	Amount0In  *big.Int
+	Amount1In  *big.Int
+	Amount0Out *big.Int
+	Amount1Out *big.Int
+	To         common.Address
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterSwap is a free log retrieval operation binding the contract event 0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822.
+//
+// Solidity: event Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)
+func (_UniswapPair *UniswapPairFilterer) FilterSwap(opts *bind.FilterOpts, sender []common.Address, to []common.Address) (*UniswapPairSwapIterator, error) {
+
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _UniswapPair.contract.FilterLogs(opts, "Swap", senderRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapPairSwapIterator{contract: _UniswapPair.contract, event: "Swap", logs: logs, sub: sub}, nil
+}
+
+// WatchSwap is a free log subscription operation binding the contract event 0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822.
+//
+// Solidity: event Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)
+func (_UniswapPair *UniswapPairFilterer) WatchSwap(opts *bind.WatchOpts, sink chan<- *UniswapPairSwap, sender []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _UniswapPair.contract.WatchLogs(opts, "Swap", senderRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(UniswapPairSwap)
+				if err := _UniswapPair.contract.UnpackLog(event, "Swap", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSwap is a log parse operation binding the contract event 0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822.
+//
+// Solidity: event Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)
+func (_UniswapPair *UniswapPairFilterer) ParseSwap(log types.Log) (*UniswapPairSwap, error) {
+	event := new(UniswapPairSwap)
+	if err := _UniswapPair.contract.UnpackLog(event, "Swap", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// UniswapPairSyncIterator is returned from FilterSync and is used to iterate over the raw logs and unpacked data for Sync events raised by the UniswapPair contract.
+type UniswapPairSyncIterator struct {
+	Event *UniswapPairSync // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *UniswapPairSyncIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(UniswapPairSync)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(UniswapPairSync)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *UniswapPairSyncIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *UniswapPairSyncIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// UniswapPairSync represents a Sync event raised by the UniswapPair contract.
+type UniswapPairSync struct {
+	Reserve0 *big.Int
+	Reserve1 *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterSync is a free log retrieval operation binding the contract event 0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1.
+//
+// Solidity: event Sync(uint112 reserve0, uint112 reserve1)
+func (_UniswapPair *UniswapPairFilterer) FilterSync(opts *bind.FilterOpts) (*UniswapPairSyncIterator, error) {
+
+	logs, sub, err := _UniswapPair.contract.FilterLogs(opts, "Sync")
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapPairSyncIterator{contract: _UniswapPair.contract, event: "Sync", logs: logs, sub: sub}, nil
+}
+
+// WatchSync is a free log subscription operation binding the contract event 0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1.
+//
+// Solidity: event Sync(uint112 reserve0, uint112 reserve1)
+func (_UniswapPair *UniswapPairFilterer) WatchSync(opts *bind.WatchOpts, sink chan<- *UniswapPairSync) (event.Subscription, error) {
+
+	logs, sub, err := _UniswapPair.contract.WatchLogs(opts, "Sync")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(UniswapPairSync)
+				if err := _UniswapPair.contract.UnpackLog(event, "Sync", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSync is a log parse operation binding the contract event 0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1.
+//
+// Solidity: event Sync(uint112 reserve0, uint112 reserve1)
+func (_UniswapPair *UniswapPairFilterer) ParseSync(log types.Log) (*UniswapPairSync, error) {
+	event := new(UniswapPairSync)
+	if err := _UniswapPair.contract.UnpackLog(event, "Sync", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// UniswapPairTransferIterator is returned from FilterTransfer and is used to iterate over the raw logs and unpacked data for Transfer events raised by the UniswapPair contract.
+type UniswapPairTransferIterator struct {
+	Event *UniswapPairTransfer // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *UniswapPairTransferIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(UniswapPairTransfer)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(UniswapPairTransfer)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *UniswapPairTransferIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *UniswapPairTransferIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// UniswapPairTransfer represents a Transfer event raised by the UniswapPair contract.
+type UniswapPairTransfer struct {
+	From  common.Address
+	To    common.Address
+	Value *big.Int
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterTransfer is a free log retrieval operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_UniswapPair *UniswapPairFilterer) FilterTransfer(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*UniswapPairTransferIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _UniswapPair.contract.FilterLogs(opts, "Transfer", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapPairTransferIterator{contract: _UniswapPair.contract, event: "Transfer", logs: logs, sub: sub}, nil
+}
+
+// WatchTransfer is a free log subscription operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_UniswapPair *UniswapPairFilterer) WatchTransfer(opts *bind.WatchOpts, sink chan<- *UniswapPairTransfer, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _UniswapPair.contract.WatchLogs(opts, "Transfer", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(UniswapPairTransfer)
+				if err := _UniswapPair.contract.UnpackLog(event, "Transfer", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTransfer is a log parse operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_UniswapPair *UniswapPairFilterer) ParseTransfer(log types.Log) (*UniswapPairTransfer, error) {
+	event := new(UniswapPairTransfer)
+	if err := _UniswapPair.contract.UnpackLog(event, "Transfer", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -613,6 +613,15 @@ func (api *RelayAPI) startValidatorRegistrationDBProcessor() {
 	}
 }
 
+// TODO - come up with better name? state interference is not really descriptive name
+func (api *RelayAPI) StateInterferenceChecks(trace *common.CallTrace) (bool, error) {
+	if api.opts.EthNetDetails.Name == "custom" {
+		return api.IsTxWEthDaiSwap(trace)
+	}
+
+	return false, fmt.Errorf("state interference checks not implemented for %s", api.opts.EthNetDetails.Name)
+}
+
 // just check if it goes to the DaiWethPair with a swap tx
 func (api *RelayAPI) IsTxWEthDaiSwap(trace *common.CallTrace) (bool, error) {
 	stack := []common.CallTrace{*trace}
@@ -1781,12 +1790,12 @@ func (api *RelayAPI) checkTobTxsStateInterference(txs []*types.Transaction, log 
 		return fmt.Errorf("failed to get traces: %s", err.Error())
 	}
 
-	res, err := api.IsTxWEthDaiSwap(&txTraces.Result)
+	res, err := api.StateInterferenceChecks(&txTraces.Result)
 	if err != nil {
-		return fmt.Errorf("failed to check if tx is a weth/dai swap: %s", err.Error())
+		return fmt.Errorf("state interference checks failed with: %s", err.Error())
 	}
 	if !res {
-		return fmt.Errorf("tx is not an weth/dai swap")
+		return fmt.Errorf("not a valid tob tx")
 	}
 
 	return nil

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -37,6 +37,7 @@ import (
 	"github.com/flashbots/go-utils/httplogger"
 	"github.com/flashbots/mev-boost-relay/beaconclient"
 	"github.com/flashbots/mev-boost-relay/common"
+	"github.com/flashbots/mev-boost-relay/contracts"
 	"github.com/flashbots/mev-boost-relay/database"
 	"github.com/flashbots/mev-boost-relay/datastore"
 	"github.com/go-redis/redis/v9"
@@ -183,6 +184,16 @@ type blockAssemblyResult struct {
 	validationErr    error
 }
 
+type tracerOptions struct {
+	log *logrus.Entry
+	tx  *types.Transaction
+}
+
+type tracerResult struct {
+	tracerResponse *common.CallTraceResponse
+	tracerError    error
+}
+
 // RelayAPI represents a single Relay instance
 type RelayAPI struct {
 	opts RelayAPIOpts
@@ -216,6 +227,7 @@ type RelayAPI struct {
 
 	blockSimRateLimiter IBlockSimRateLimiter
 	blockAssembler      IBlockAssembler
+	tracer              ITracer
 
 	validatorRegC chan boostTypes.SignedValidatorRegistration
 
@@ -242,6 +254,30 @@ type RelayAPI struct {
 	optimisticBlocksWG sync.WaitGroup
 	// Cache for builder statuses and collaterals.
 	blockBuildersCache map[string]*blockBuilderCacheEntry
+
+	// stores DeFi contract addresses rquired for state interference checks
+	defiAddresses map[string]common2.Address
+}
+
+func FillUpDefiAddresses(opts RelayAPIOpts) map[string]common2.Address {
+	defiAddresses := make(map[string]common2.Address)
+
+	if opts.EthNetDetails.Name == "mainnet" {
+		// TODO - fill up mainnet defi addresses
+	} else if opts.EthNetDetails.Name == "goerli" {
+		// TODO - fill up goerli addresses
+	}
+
+	defiAddresses[common.DaiToken] = common2.HexToAddress("0xAb2A01BC351770D09611Ac80f1DE076D56E0487d")
+	defiAddresses[common.WethToken] = common2.HexToAddress("0x4c849Ff66a6F0A954cbf7818b8a763105C2787D6")
+
+	// this is only in custom kurtosis devnets
+	defiAddresses[common.DaiWethPair1] = common2.HexToAddress("0x0D6b80a9Cefc2C58308F0Adc26586E550E4422ef")
+	defiAddresses[common.UniswapFactory1] = common2.HexToAddress("0xBFF5cD0aA560e1d1C6B1E2C347860aDAe1bd8235")
+	defiAddresses[common.DaiWethPair2] = common2.HexToAddress("0x2ed2B47342450C006F83913a422F7C2BDAB8377a")
+	defiAddresses[common.UniswapFactory2] = common2.HexToAddress("0x6bEaE43B589D986d127Bd2BdAcF4e24C41C5C035")
+
+	return defiAddresses
 }
 
 // NewRelayAPI creates a new service. if builders is nil, allow any builder
@@ -307,8 +343,11 @@ func NewRelayAPI(opts RelayAPIOpts) (api *RelayAPI, err error) {
 		proposerDutiesResponse: &[]byte{},
 		blockSimRateLimiter:    NewBlockSimulationRateLimiter(opts.BlockSimURL),
 		blockAssembler:         NewBlockAssembler(opts.BlockSimURL),
+		tracer:                 NewTracer(opts.BlockSimURL),
 
 		validatorRegC: make(chan boostTypes.SignedValidatorRegistration, 450_000),
+
+		defiAddresses: FillUpDefiAddresses(opts),
 	}
 
 	if os.Getenv("FORCE_GET_HEADER_204") == "1" {
@@ -572,6 +611,77 @@ func (api *RelayAPI) startValidatorRegistrationDBProcessor() {
 			}).Error("error saving validator registration")
 		}
 	}
+}
+
+// just check if it goes to the DaiWethPair with a swap tx
+func (api *RelayAPI) IsTxWEthDaiSwap(trace *common.CallTrace) (bool, error) {
+	stack := []common.CallTrace{*trace}
+
+	for len(stack) > 0 {
+		current := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		res, err := api.IsTraceToWEthDaiPair(current)
+		if err != nil {
+			return false, err
+		}
+		// we found a weth/dai swap i.e the tx contains a weth/dai swap
+		if res {
+			return true, nil
+		}
+
+		for _, call := range current.Calls {
+			stack = append(stack, call)
+		}
+	}
+
+	return false, nil
+}
+
+// This will change based on the state interference check
+func (api *RelayAPI) IsTraceToWEthDaiPair(callTrace common.CallTrace) (bool, error) {
+	if callTrace.To == nil {
+		return false, nil
+	}
+	if callTrace.Type == "STATICCALL" {
+		return false, nil
+	}
+
+	uniswapDaiWethAddress1 := api.defiAddresses[common.DaiWethPair1]
+	uniswapDaiWethAddress2 := api.defiAddresses[common.DaiWethPair2]
+	if *callTrace.To != uniswapDaiWethAddress1 && *callTrace.To != uniswapDaiWethAddress2 {
+		return false, nil
+	}
+
+	if len(callTrace.Input) < 4 {
+		return false, nil
+	}
+
+	// this will be the same across all environments
+	uniswapPairAbi, err := contracts.UniswapPairMetaData.GetAbi()
+	if err != nil {
+		return false, err
+	}
+	swapId := uniswapPairAbi.Methods["swap"].ID
+	if !bytes.Equal(callTrace.Input[:4], swapId) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (api *RelayAPI) getTraces(ctx context.Context, opts tracerOptions) (*common.CallTraceResponse, error) {
+	t := time.Now()
+	res, err := api.tracer.TraceTx(ctx, opts.tx)
+	log := opts.log.WithFields(logrus.Fields{
+		"durationMs": time.Since(t).Milliseconds(),
+	})
+	if err != nil {
+		log.WithError(err).Warn("tracer failed")
+		return nil, err
+	}
+	log.Info("tracer successful")
+	return res, nil
 }
 
 // simulateBlock sends a request for a block simulation to blockSimRateLimiter.
@@ -1651,30 +1761,40 @@ func (api *RelayAPI) checkBuilderEntry(w http.ResponseWriter, log *logrus.Entry,
 }
 
 // Checks the quality of the TOB txs, if it is the txs expected in a TOB
-func (api *RelayAPI) checkTobTxsStateInterference(txs []*types.Transaction) error {
+func (api *RelayAPI) checkTobTxsStateInterference(txs []*types.Transaction, log *logrus.Entry) error {
 	if len(txs) > 2 {
 		return fmt.Errorf("we support only 1 tx on the TOB currently, got %d", len(txs))
 	}
 
+	// get traces
 	firstTx := txs[0]
+	// some sanity checks
 	if firstTx.To() == nil {
 		return fmt.Errorf("contract creation cannot be a TOB tx")
 	}
-	// This address is from the kurtosis local devnet. Need to expand state interference checks
-	if *firstTx.To() != common2.HexToAddress("0xB9D7a3554F221B34f49d7d3C61375E603aFb699e") {
-		return fmt.Errorf("TOB tx can only be sent to uniswap v2 router")
+
+	txTraces, err := api.getTraces(context.Background(), tracerOptions{
+		log: log,
+		tx:  firstTx,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get traces: %s", err.Error())
 	}
 
-	// TODO - add check for whether the tx is a eth/usdc swap
+	res, err := api.IsTxWEthDaiSwap(&txTraces.Result)
+	if err != nil {
+		return fmt.Errorf("failed to check if tx is a weth/dai swap: %s", err.Error())
+	}
+	if !res {
+		return fmt.Errorf("tx is not an weth/dai swap")
+	}
+
 	return nil
 }
 
 // This method first checks whether the payouts are valid, then checks whether the txs are valid w.r.t state interference
-func (api *RelayAPI) checkTxAndSenderValidity(txs []*types.Transaction) error {
+func (api *RelayAPI) checkTxAndSenderValidity(txs []*types.Transaction, log *logrus.Entry) error {
 	// TODO - Payouts still need to be modelled
-	// TODO - check all the txs to see if the nonce is valid, value is valid, check if the tx has already been included. These can be confirmed from the
-	// execution layer. We should ideally
-	// TODO - expand state interference checks as in checkTobTxsStateInterference
 
 	if len(txs) == 0 {
 		return fmt.Errorf("Empty TOB tx request sent!")
@@ -1697,7 +1817,7 @@ func (api *RelayAPI) checkTxAndSenderValidity(txs []*types.Transaction) error {
 	}
 
 	// State interference checks
-	return api.checkTobTxsStateInterference(txs)
+	return api.checkTobTxsStateInterference(txs, log)
 }
 
 func (api *RelayAPI) handleSubmitNewTobTxs(w http.ResponseWriter, req *http.Request) {
@@ -1777,7 +1897,7 @@ func (api *RelayAPI) handleSubmitNewTobTxs(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	err = api.checkTxAndSenderValidity(txs)
+	err = api.checkTxAndSenderValidity(txs, log)
 	if err != nil {
 		log.WithError(err).Error("error validating the txs")
 		api.RespondError(w, http.StatusBadRequest, err.Error())


### PR DESCRIPTION
## 📝 Summary

We use all our tracing infra to implement state interference in a custom devnet at this point. In custom devnets, we check if our ToB tx is a uniswap v2 swap of Dai/Weth. 
To check if our ToB tx performs a uniswap v2 Dai/Weth swap, we fetch the callTraces of the tx. To learn more about callTracing and EVM tracing, please refer to https://geth.ethereum.org/docs/developers/evm-tracing
The callTraces break down a complex tx into individual sub-txs called traces. We inspect these traces to check if any trace maps to a uniswap v2 weth/dai swap. We perform this check by checking if the `To` address of the trace is the uniswap v2 Dai/Weth pool. If that is correct, we check the input bytes of the tx, we check the first 4 bytes, which are the method of the smart contract call. We check if the methodId maps to the swap smart contract method in the uniswap v2 pool smart contract. 
We could hardcode methodId bytes in the codebase but to make the methodId check much more robust, we use go-bindings of the uniswap v2 pool smart contract generated by abigen(https://geth.ethereum.org/docs/tools/abigen#what-is-an-abi) . We look up the methodId of the swap smart contract method using these bindings. If the input bytes correspond to this methodId, we can conclude that this ToB tx is indeed a valid wEth/Dai swap