### PR TITLE
[PEPC-Boost][13] Add state interference checks for Goerli

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -47,11 +47,13 @@ var (
 	// this is for storing DeFi addresses for state interference checks
 	DaiToken  = "dai"
 	WethToken = "weth"
+	UsdcToken = "usdc"
 	// 2 addresses are specifically in custom devnet, we have 2 pairs of Dai/Weth for arbitrage tests
 	DaiWethPair1    = "dai_weth_pair_1"
 	DaiWethPair2    = "dai_weth_pair_2"
 	UniswapFactory1 = "uniswap_factory_1"
 	UniswapFactory2 = "uniswap_factory_2"
+	UniV3SwapRouter = "uniswap_v3_swap_router"
 )
 
 type EthNetworkDetails struct {
@@ -955,3 +957,5 @@ type CallTrace struct {
 type CallTraceResponse struct {
 	Result CallTrace `json:"result"`
 }
+
+type NetworkStateInterferenceChecker func(CallTrace) (bool, error)

--- a/common/utils.go
+++ b/common/utils.go
@@ -20,6 +20,7 @@ import (
 	v1 "github.com/attestantio/go-builder-client/api/v1"
 	capellaspec "github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/flashbots/go-boost-utils/bls"
@@ -246,4 +247,14 @@ func GetEnvDurationSec(key string, defaultValueSec int) time.Duration {
 		}
 	}
 	return time.Duration(defaultValueSec) * time.Second
+}
+
+func GetMethodArgs(data []byte, method string, contractAbi *abi.ABI) (interface{}, error) {
+	abiMethod := contractAbi.Methods[method]
+	res, err := abiMethod.Inputs.Unpack(data[4:])
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }

--- a/common/utils.go
+++ b/common/utils.go
@@ -256,5 +256,5 @@ func GetMethodArgs(data []byte, method string, contractAbi *abi.ABI) (interface{
 		return nil, err
 	}
 
-	return res, nil
+	return res[0], nil
 }

--- a/contracts/uniswap-v3-swap-router.go
+++ b/contracts/uniswap-v3-swap-router.go
@@ -1,0 +1,621 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package contracts
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// ISwapRouterExactInputParams is an auto generated low-level Go binding around an user-defined struct.
+type ISwapRouterExactInputParams struct {
+	Path             []byte
+	Recipient        common.Address
+	Deadline         *big.Int
+	AmountIn         *big.Int
+	AmountOutMinimum *big.Int
+}
+
+// ISwapRouterExactInputSingleParams is an auto generated low-level Go binding around an user-defined struct.
+type ISwapRouterExactInputSingleParams struct {
+	TokenIn           common.Address
+	TokenOut          common.Address
+	Fee               *big.Int
+	Recipient         common.Address
+	Deadline          *big.Int
+	AmountIn          *big.Int
+	AmountOutMinimum  *big.Int
+	SqrtPriceLimitX96 *big.Int
+}
+
+// ISwapRouterExactOutputParams is an auto generated low-level Go binding around an user-defined struct.
+type ISwapRouterExactOutputParams struct {
+	Path            []byte
+	Recipient       common.Address
+	Deadline        *big.Int
+	AmountOut       *big.Int
+	AmountInMaximum *big.Int
+}
+
+// ISwapRouterExactOutputSingleParams is an auto generated low-level Go binding around an user-defined struct.
+type ISwapRouterExactOutputSingleParams struct {
+	TokenIn           common.Address
+	TokenOut          common.Address
+	Fee               *big.Int
+	Recipient         common.Address
+	Deadline          *big.Int
+	AmountOut         *big.Int
+	AmountInMaximum   *big.Int
+	SqrtPriceLimitX96 *big.Int
+}
+
+// UniswapV3SwapRouterMetaData contains all meta data concerning the UniswapV3SwapRouter contract.
+var UniswapV3SwapRouterMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_factory\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_WETH9\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"WETH9\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes\",\"name\":\"path\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountOutMinimum\",\"type\":\"uint256\"}],\"internalType\":\"structISwapRouter.ExactInputParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"exactInput\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"tokenIn\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"tokenOut\",\"type\":\"address\"},{\"internalType\":\"uint24\",\"name\":\"fee\",\"type\":\"uint24\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountOutMinimum\",\"type\":\"uint256\"},{\"internalType\":\"uint160\",\"name\":\"sqrtPriceLimitX96\",\"type\":\"uint160\"}],\"internalType\":\"structISwapRouter.ExactInputSingleParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"exactInputSingle\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes\",\"name\":\"path\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountInMaximum\",\"type\":\"uint256\"}],\"internalType\":\"structISwapRouter.ExactOutputParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"exactOutput\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"tokenIn\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"tokenOut\",\"type\":\"address\"},{\"internalType\":\"uint24\",\"name\":\"fee\",\"type\":\"uint24\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountInMaximum\",\"type\":\"uint256\"},{\"internalType\":\"uint160\",\"name\":\"sqrtPriceLimitX96\",\"type\":\"uint160\"}],\"internalType\":\"structISwapRouter.ExactOutputSingleParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"exactOutputSingle\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"factory\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes[]\",\"name\":\"data\",\"type\":\"bytes[]\"}],\"name\":\"multicall\",\"outputs\":[{\"internalType\":\"bytes[]\",\"name\":\"results\",\"type\":\"bytes[]\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"refundETH\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"selfPermit\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"selfPermitAllowed\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"selfPermitAllowedIfNecessary\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"selfPermitIfNecessary\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"sweepToken\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"feeBips\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"feeRecipient\",\"type\":\"address\"}],\"name\":\"sweepTokenWithFee\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"int256\",\"name\":\"amount0Delta\",\"type\":\"int256\"},{\"internalType\":\"int256\",\"name\":\"amount1Delta\",\"type\":\"int256\"},{\"internalType\":\"bytes\",\"name\":\"_data\",\"type\":\"bytes\"}],\"name\":\"uniswapV3SwapCallback\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"unwrapWETH9\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"feeBips\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"feeRecipient\",\"type\":\"address\"}],\"name\":\"unwrapWETH9WithFee\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
+}
+
+// UniswapV3SwapRouterABI is the input ABI used to generate the binding from.
+// Deprecated: Use UniswapV3SwapRouterMetaData.ABI instead.
+var UniswapV3SwapRouterABI = UniswapV3SwapRouterMetaData.ABI
+
+// UniswapV3SwapRouter is an auto generated Go binding around an Ethereum contract.
+type UniswapV3SwapRouter struct {
+	UniswapV3SwapRouterCaller     // Read-only binding to the contract
+	UniswapV3SwapRouterTransactor // Write-only binding to the contract
+	UniswapV3SwapRouterFilterer   // Log filterer for contract events
+}
+
+// UniswapV3SwapRouterCaller is an auto generated read-only Go binding around an Ethereum contract.
+type UniswapV3SwapRouterCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniswapV3SwapRouterTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type UniswapV3SwapRouterTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniswapV3SwapRouterFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type UniswapV3SwapRouterFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniswapV3SwapRouterSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type UniswapV3SwapRouterSession struct {
+	Contract     *UniswapV3SwapRouter // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts        // Call options to use throughout this session
+	TransactOpts bind.TransactOpts    // Transaction auth options to use throughout this session
+}
+
+// UniswapV3SwapRouterCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type UniswapV3SwapRouterCallerSession struct {
+	Contract *UniswapV3SwapRouterCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts              // Call options to use throughout this session
+}
+
+// UniswapV3SwapRouterTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type UniswapV3SwapRouterTransactorSession struct {
+	Contract     *UniswapV3SwapRouterTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts              // Transaction auth options to use throughout this session
+}
+
+// UniswapV3SwapRouterRaw is an auto generated low-level Go binding around an Ethereum contract.
+type UniswapV3SwapRouterRaw struct {
+	Contract *UniswapV3SwapRouter // Generic contract binding to access the raw methods on
+}
+
+// UniswapV3SwapRouterCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type UniswapV3SwapRouterCallerRaw struct {
+	Contract *UniswapV3SwapRouterCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// UniswapV3SwapRouterTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type UniswapV3SwapRouterTransactorRaw struct {
+	Contract *UniswapV3SwapRouterTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewUniswapV3SwapRouter creates a new instance of UniswapV3SwapRouter, bound to a specific deployed contract.
+func NewUniswapV3SwapRouter(address common.Address, backend bind.ContractBackend) (*UniswapV3SwapRouter, error) {
+	contract, err := bindUniswapV3SwapRouter(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapV3SwapRouter{UniswapV3SwapRouterCaller: UniswapV3SwapRouterCaller{contract: contract}, UniswapV3SwapRouterTransactor: UniswapV3SwapRouterTransactor{contract: contract}, UniswapV3SwapRouterFilterer: UniswapV3SwapRouterFilterer{contract: contract}}, nil
+}
+
+// NewUniswapV3SwapRouterCaller creates a new read-only instance of UniswapV3SwapRouter, bound to a specific deployed contract.
+func NewUniswapV3SwapRouterCaller(address common.Address, caller bind.ContractCaller) (*UniswapV3SwapRouterCaller, error) {
+	contract, err := bindUniswapV3SwapRouter(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapV3SwapRouterCaller{contract: contract}, nil
+}
+
+// NewUniswapV3SwapRouterTransactor creates a new write-only instance of UniswapV3SwapRouter, bound to a specific deployed contract.
+func NewUniswapV3SwapRouterTransactor(address common.Address, transactor bind.ContractTransactor) (*UniswapV3SwapRouterTransactor, error) {
+	contract, err := bindUniswapV3SwapRouter(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapV3SwapRouterTransactor{contract: contract}, nil
+}
+
+// NewUniswapV3SwapRouterFilterer creates a new log filterer instance of UniswapV3SwapRouter, bound to a specific deployed contract.
+func NewUniswapV3SwapRouterFilterer(address common.Address, filterer bind.ContractFilterer) (*UniswapV3SwapRouterFilterer, error) {
+	contract, err := bindUniswapV3SwapRouter(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &UniswapV3SwapRouterFilterer{contract: contract}, nil
+}
+
+// bindUniswapV3SwapRouter binds a generic wrapper to an already deployed contract.
+func bindUniswapV3SwapRouter(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := UniswapV3SwapRouterMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _UniswapV3SwapRouter.Contract.UniswapV3SwapRouterCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.UniswapV3SwapRouterTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.UniswapV3SwapRouterTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _UniswapV3SwapRouter.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.contract.Transact(opts, method, params...)
+}
+
+// WETH9 is a free data retrieval call binding the contract method 0x4aa4a4fc.
+//
+// Solidity: function WETH9() view returns(address)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterCaller) WETH9(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _UniswapV3SwapRouter.contract.Call(opts, &out, "WETH9")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// WETH9 is a free data retrieval call binding the contract method 0x4aa4a4fc.
+//
+// Solidity: function WETH9() view returns(address)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) WETH9() (common.Address, error) {
+	return _UniswapV3SwapRouter.Contract.WETH9(&_UniswapV3SwapRouter.CallOpts)
+}
+
+// WETH9 is a free data retrieval call binding the contract method 0x4aa4a4fc.
+//
+// Solidity: function WETH9() view returns(address)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterCallerSession) WETH9() (common.Address, error) {
+	return _UniswapV3SwapRouter.Contract.WETH9(&_UniswapV3SwapRouter.CallOpts)
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterCaller) Factory(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _UniswapV3SwapRouter.contract.Call(opts, &out, "factory")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) Factory() (common.Address, error) {
+	return _UniswapV3SwapRouter.Contract.Factory(&_UniswapV3SwapRouter.CallOpts)
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterCallerSession) Factory() (common.Address, error) {
+	return _UniswapV3SwapRouter.Contract.Factory(&_UniswapV3SwapRouter.CallOpts)
+}
+
+// ExactInput is a paid mutator transaction binding the contract method 0xc04b8d59.
+//
+// Solidity: function exactInput((bytes,address,uint256,uint256,uint256) params) payable returns(uint256 amountOut)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) ExactInput(opts *bind.TransactOpts, params ISwapRouterExactInputParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "exactInput", params)
+}
+
+// ExactInput is a paid mutator transaction binding the contract method 0xc04b8d59.
+//
+// Solidity: function exactInput((bytes,address,uint256,uint256,uint256) params) payable returns(uint256 amountOut)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) ExactInput(params ISwapRouterExactInputParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.ExactInput(&_UniswapV3SwapRouter.TransactOpts, params)
+}
+
+// ExactInput is a paid mutator transaction binding the contract method 0xc04b8d59.
+//
+// Solidity: function exactInput((bytes,address,uint256,uint256,uint256) params) payable returns(uint256 amountOut)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) ExactInput(params ISwapRouterExactInputParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.ExactInput(&_UniswapV3SwapRouter.TransactOpts, params)
+}
+
+// ExactInputSingle is a paid mutator transaction binding the contract method 0x414bf389.
+//
+// Solidity: function exactInputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160) params) payable returns(uint256 amountOut)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) ExactInputSingle(opts *bind.TransactOpts, params ISwapRouterExactInputSingleParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "exactInputSingle", params)
+}
+
+// ExactInputSingle is a paid mutator transaction binding the contract method 0x414bf389.
+//
+// Solidity: function exactInputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160) params) payable returns(uint256 amountOut)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) ExactInputSingle(params ISwapRouterExactInputSingleParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.ExactInputSingle(&_UniswapV3SwapRouter.TransactOpts, params)
+}
+
+// ExactInputSingle is a paid mutator transaction binding the contract method 0x414bf389.
+//
+// Solidity: function exactInputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160) params) payable returns(uint256 amountOut)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) ExactInputSingle(params ISwapRouterExactInputSingleParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.ExactInputSingle(&_UniswapV3SwapRouter.TransactOpts, params)
+}
+
+// ExactOutput is a paid mutator transaction binding the contract method 0xf28c0498.
+//
+// Solidity: function exactOutput((bytes,address,uint256,uint256,uint256) params) payable returns(uint256 amountIn)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) ExactOutput(opts *bind.TransactOpts, params ISwapRouterExactOutputParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "exactOutput", params)
+}
+
+// ExactOutput is a paid mutator transaction binding the contract method 0xf28c0498.
+//
+// Solidity: function exactOutput((bytes,address,uint256,uint256,uint256) params) payable returns(uint256 amountIn)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) ExactOutput(params ISwapRouterExactOutputParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.ExactOutput(&_UniswapV3SwapRouter.TransactOpts, params)
+}
+
+// ExactOutput is a paid mutator transaction binding the contract method 0xf28c0498.
+//
+// Solidity: function exactOutput((bytes,address,uint256,uint256,uint256) params) payable returns(uint256 amountIn)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) ExactOutput(params ISwapRouterExactOutputParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.ExactOutput(&_UniswapV3SwapRouter.TransactOpts, params)
+}
+
+// ExactOutputSingle is a paid mutator transaction binding the contract method 0xdb3e2198.
+//
+// Solidity: function exactOutputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160) params) payable returns(uint256 amountIn)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) ExactOutputSingle(opts *bind.TransactOpts, params ISwapRouterExactOutputSingleParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "exactOutputSingle", params)
+}
+
+// ExactOutputSingle is a paid mutator transaction binding the contract method 0xdb3e2198.
+//
+// Solidity: function exactOutputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160) params) payable returns(uint256 amountIn)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) ExactOutputSingle(params ISwapRouterExactOutputSingleParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.ExactOutputSingle(&_UniswapV3SwapRouter.TransactOpts, params)
+}
+
+// ExactOutputSingle is a paid mutator transaction binding the contract method 0xdb3e2198.
+//
+// Solidity: function exactOutputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160) params) payable returns(uint256 amountIn)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) ExactOutputSingle(params ISwapRouterExactOutputSingleParams) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.ExactOutputSingle(&_UniswapV3SwapRouter.TransactOpts, params)
+}
+
+// Multicall is a paid mutator transaction binding the contract method 0xac9650d8.
+//
+// Solidity: function multicall(bytes[] data) payable returns(bytes[] results)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) Multicall(opts *bind.TransactOpts, data [][]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "multicall", data)
+}
+
+// Multicall is a paid mutator transaction binding the contract method 0xac9650d8.
+//
+// Solidity: function multicall(bytes[] data) payable returns(bytes[] results)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) Multicall(data [][]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.Multicall(&_UniswapV3SwapRouter.TransactOpts, data)
+}
+
+// Multicall is a paid mutator transaction binding the contract method 0xac9650d8.
+//
+// Solidity: function multicall(bytes[] data) payable returns(bytes[] results)
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) Multicall(data [][]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.Multicall(&_UniswapV3SwapRouter.TransactOpts, data)
+}
+
+// RefundETH is a paid mutator transaction binding the contract method 0x12210e8a.
+//
+// Solidity: function refundETH() payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) RefundETH(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "refundETH")
+}
+
+// RefundETH is a paid mutator transaction binding the contract method 0x12210e8a.
+//
+// Solidity: function refundETH() payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) RefundETH() (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.RefundETH(&_UniswapV3SwapRouter.TransactOpts)
+}
+
+// RefundETH is a paid mutator transaction binding the contract method 0x12210e8a.
+//
+// Solidity: function refundETH() payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) RefundETH() (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.RefundETH(&_UniswapV3SwapRouter.TransactOpts)
+}
+
+// SelfPermit is a paid mutator transaction binding the contract method 0xf3995c67.
+//
+// Solidity: function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) SelfPermit(opts *bind.TransactOpts, token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "selfPermit", token, value, deadline, v, r, s)
+}
+
+// SelfPermit is a paid mutator transaction binding the contract method 0xf3995c67.
+//
+// Solidity: function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) SelfPermit(token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SelfPermit(&_UniswapV3SwapRouter.TransactOpts, token, value, deadline, v, r, s)
+}
+
+// SelfPermit is a paid mutator transaction binding the contract method 0xf3995c67.
+//
+// Solidity: function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) SelfPermit(token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SelfPermit(&_UniswapV3SwapRouter.TransactOpts, token, value, deadline, v, r, s)
+}
+
+// SelfPermitAllowed is a paid mutator transaction binding the contract method 0x4659a494.
+//
+// Solidity: function selfPermitAllowed(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) SelfPermitAllowed(opts *bind.TransactOpts, token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "selfPermitAllowed", token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitAllowed is a paid mutator transaction binding the contract method 0x4659a494.
+//
+// Solidity: function selfPermitAllowed(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) SelfPermitAllowed(token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SelfPermitAllowed(&_UniswapV3SwapRouter.TransactOpts, token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitAllowed is a paid mutator transaction binding the contract method 0x4659a494.
+//
+// Solidity: function selfPermitAllowed(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) SelfPermitAllowed(token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SelfPermitAllowed(&_UniswapV3SwapRouter.TransactOpts, token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitAllowedIfNecessary is a paid mutator transaction binding the contract method 0xa4a78f0c.
+//
+// Solidity: function selfPermitAllowedIfNecessary(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) SelfPermitAllowedIfNecessary(opts *bind.TransactOpts, token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "selfPermitAllowedIfNecessary", token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitAllowedIfNecessary is a paid mutator transaction binding the contract method 0xa4a78f0c.
+//
+// Solidity: function selfPermitAllowedIfNecessary(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) SelfPermitAllowedIfNecessary(token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SelfPermitAllowedIfNecessary(&_UniswapV3SwapRouter.TransactOpts, token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitAllowedIfNecessary is a paid mutator transaction binding the contract method 0xa4a78f0c.
+//
+// Solidity: function selfPermitAllowedIfNecessary(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) SelfPermitAllowedIfNecessary(token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SelfPermitAllowedIfNecessary(&_UniswapV3SwapRouter.TransactOpts, token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitIfNecessary is a paid mutator transaction binding the contract method 0xc2e3140a.
+//
+// Solidity: function selfPermitIfNecessary(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) SelfPermitIfNecessary(opts *bind.TransactOpts, token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "selfPermitIfNecessary", token, value, deadline, v, r, s)
+}
+
+// SelfPermitIfNecessary is a paid mutator transaction binding the contract method 0xc2e3140a.
+//
+// Solidity: function selfPermitIfNecessary(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) SelfPermitIfNecessary(token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SelfPermitIfNecessary(&_UniswapV3SwapRouter.TransactOpts, token, value, deadline, v, r, s)
+}
+
+// SelfPermitIfNecessary is a paid mutator transaction binding the contract method 0xc2e3140a.
+//
+// Solidity: function selfPermitIfNecessary(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) SelfPermitIfNecessary(token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SelfPermitIfNecessary(&_UniswapV3SwapRouter.TransactOpts, token, value, deadline, v, r, s)
+}
+
+// SweepToken is a paid mutator transaction binding the contract method 0xdf2ab5bb.
+//
+// Solidity: function sweepToken(address token, uint256 amountMinimum, address recipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) SweepToken(opts *bind.TransactOpts, token common.Address, amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "sweepToken", token, amountMinimum, recipient)
+}
+
+// SweepToken is a paid mutator transaction binding the contract method 0xdf2ab5bb.
+//
+// Solidity: function sweepToken(address token, uint256 amountMinimum, address recipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) SweepToken(token common.Address, amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SweepToken(&_UniswapV3SwapRouter.TransactOpts, token, amountMinimum, recipient)
+}
+
+// SweepToken is a paid mutator transaction binding the contract method 0xdf2ab5bb.
+//
+// Solidity: function sweepToken(address token, uint256 amountMinimum, address recipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) SweepToken(token common.Address, amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SweepToken(&_UniswapV3SwapRouter.TransactOpts, token, amountMinimum, recipient)
+}
+
+// SweepTokenWithFee is a paid mutator transaction binding the contract method 0xe0e189a0.
+//
+// Solidity: function sweepTokenWithFee(address token, uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) SweepTokenWithFee(opts *bind.TransactOpts, token common.Address, amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "sweepTokenWithFee", token, amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// SweepTokenWithFee is a paid mutator transaction binding the contract method 0xe0e189a0.
+//
+// Solidity: function sweepTokenWithFee(address token, uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) SweepTokenWithFee(token common.Address, amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SweepTokenWithFee(&_UniswapV3SwapRouter.TransactOpts, token, amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// SweepTokenWithFee is a paid mutator transaction binding the contract method 0xe0e189a0.
+//
+// Solidity: function sweepTokenWithFee(address token, uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) SweepTokenWithFee(token common.Address, amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.SweepTokenWithFee(&_UniswapV3SwapRouter.TransactOpts, token, amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// UniswapV3SwapCallback is a paid mutator transaction binding the contract method 0xfa461e33.
+//
+// Solidity: function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes _data) returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) UniswapV3SwapCallback(opts *bind.TransactOpts, amount0Delta *big.Int, amount1Delta *big.Int, _data []byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "uniswapV3SwapCallback", amount0Delta, amount1Delta, _data)
+}
+
+// UniswapV3SwapCallback is a paid mutator transaction binding the contract method 0xfa461e33.
+//
+// Solidity: function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes _data) returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) UniswapV3SwapCallback(amount0Delta *big.Int, amount1Delta *big.Int, _data []byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.UniswapV3SwapCallback(&_UniswapV3SwapRouter.TransactOpts, amount0Delta, amount1Delta, _data)
+}
+
+// UniswapV3SwapCallback is a paid mutator transaction binding the contract method 0xfa461e33.
+//
+// Solidity: function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes _data) returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) UniswapV3SwapCallback(amount0Delta *big.Int, amount1Delta *big.Int, _data []byte) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.UniswapV3SwapCallback(&_UniswapV3SwapRouter.TransactOpts, amount0Delta, amount1Delta, _data)
+}
+
+// UnwrapWETH9 is a paid mutator transaction binding the contract method 0x49404b7c.
+//
+// Solidity: function unwrapWETH9(uint256 amountMinimum, address recipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) UnwrapWETH9(opts *bind.TransactOpts, amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "unwrapWETH9", amountMinimum, recipient)
+}
+
+// UnwrapWETH9 is a paid mutator transaction binding the contract method 0x49404b7c.
+//
+// Solidity: function unwrapWETH9(uint256 amountMinimum, address recipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) UnwrapWETH9(amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.UnwrapWETH9(&_UniswapV3SwapRouter.TransactOpts, amountMinimum, recipient)
+}
+
+// UnwrapWETH9 is a paid mutator transaction binding the contract method 0x49404b7c.
+//
+// Solidity: function unwrapWETH9(uint256 amountMinimum, address recipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) UnwrapWETH9(amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.UnwrapWETH9(&_UniswapV3SwapRouter.TransactOpts, amountMinimum, recipient)
+}
+
+// UnwrapWETH9WithFee is a paid mutator transaction binding the contract method 0x9b2c0a37.
+//
+// Solidity: function unwrapWETH9WithFee(uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) UnwrapWETH9WithFee(opts *bind.TransactOpts, amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.Transact(opts, "unwrapWETH9WithFee", amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// UnwrapWETH9WithFee is a paid mutator transaction binding the contract method 0x9b2c0a37.
+//
+// Solidity: function unwrapWETH9WithFee(uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) UnwrapWETH9WithFee(amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.UnwrapWETH9WithFee(&_UniswapV3SwapRouter.TransactOpts, amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// UnwrapWETH9WithFee is a paid mutator transaction binding the contract method 0x9b2c0a37.
+//
+// Solidity: function unwrapWETH9WithFee(uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) UnwrapWETH9WithFee(amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.UnwrapWETH9WithFee(&_UniswapV3SwapRouter.TransactOpts, amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterSession) Receive() (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.Receive(&_UniswapV3SwapRouter.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_UniswapV3SwapRouter *UniswapV3SwapRouterTransactorSession) Receive() (*types.Transaction, error) {
+	return _UniswapV3SwapRouter.Contract.Receive(&_UniswapV3SwapRouter.TransactOpts)
+}

--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -58,7 +58,7 @@ type blockRequestOpts struct {
 	domain     boostTypes.Domain
 }
 
-func startTestBackend(t *testing.T) (*phase0.BLSPubKey, *bls.SecretKey, *testBackend) {
+func startTestBackend(t *testing.T, network string) (*phase0.BLSPubKey, *bls.SecretKey, *testBackend) {
 	t.Helper()
 	// Setup test key pair.
 	sk, _, err := bls.GenerateNewKeypair()
@@ -71,7 +71,7 @@ func startTestBackend(t *testing.T) (*phase0.BLSPubKey, *bls.SecretKey, *testBac
 	pkStr := pubkey.String()
 
 	// Setup test backend.
-	backend := newTestBackend(t, 1)
+	backend := newTestBackend(t, 1, network)
 	backend.relay.genesisInfo = &beaconclient.GetGenesisResponse{}
 	backend.relay.genesisInfo.Data.GenesisTime = 0
 	backend.relay.proposerDutiesMap = map[uint64]*common.BuilderGetValidatorsResponseEntry{
@@ -175,7 +175,7 @@ func TestSimulateBlock(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			pubkey, secretkey, backend := startTestBackend(t)
+			pubkey, secretkey, backend := startTestBackend(t, common.EthNetworkMainnet)
 			backend.relay.blockSimRateLimiter = &MockBlockSimulationRateLimiter{
 				simulationError: tc.simulationError,
 			}
@@ -223,7 +223,7 @@ func TestProcessOptimisticBlock(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			pubkey, secretkey, backend := startTestBackend(t)
+			pubkey, secretkey, backend := startTestBackend(t, common.EthNetworkMainnet)
 			pkStr := pubkey.String()
 			backend.relay.blockSimRateLimiter = &MockBlockSimulationRateLimiter{
 				simulationError: tc.simulationError,
@@ -272,7 +272,7 @@ func TestDemoteBuilder(t *testing.T) {
 		IsOptimistic: false,
 		IsHighPrio:   true,
 	}
-	pubkey, secretkey, backend := startTestBackend(t)
+	pubkey, secretkey, backend := startTestBackend(t, common.EthNetworkMainnet)
 	pkStr := pubkey.String()
 	req := common.TestBuilderSubmitBlockRequest(secretkey, getTestBidTrace(*pubkey, collateral))
 	backend.relay.demoteBuilder(pkStr, &req, errFake)
@@ -290,7 +290,7 @@ func TestDemoteBuilder(t *testing.T) {
 }
 
 func TestPrepareBuildersForSlot(t *testing.T) {
-	pubkey, _, backend := startTestBackend(t)
+	pubkey, _, backend := startTestBackend(t, common.EthNetworkMainnet)
 	pkStr := pubkey.String()
 	// Clear cache.
 	backend.relay.blockBuildersCache = map[string]*blockBuilderCacheEntry{}
@@ -392,7 +392,7 @@ func TestPrepareBuildersForSlot(t *testing.T) {
 //}
 
 func TestInternalBuilderStatus(t *testing.T) {
-	pubkey, _, backend := startTestBackend(t)
+	pubkey, _, backend := startTestBackend(t, common.EthNetworkMainnet)
 	// Set all to false initially.
 	err := backend.relay.db.SetBlockBuilderStatus(pubkey.String(), common.BuilderStatus{})
 	require.NoError(t, err)
@@ -419,7 +419,7 @@ func TestInternalBuilderStatus(t *testing.T) {
 }
 
 func TestInternalBuilderCollateral(t *testing.T) {
-	pubkey, _, backend := startTestBackend(t)
+	pubkey, _, backend := startTestBackend(t, common.EthNetworkMainnet)
 	path := "/internal/v1/builder/collateral/" + pubkey.String()
 
 	// Set & Get.

--- a/services/api/pepc_boost_test.go
+++ b/services/api/pepc_boost_test.go
@@ -157,8 +157,6 @@ func GetTestPayloadAttributes(t *testing.T) (string, types.Address, []byte, stri
 }
 
 func TestIsTxWEthDaiSwap(t *testing.T) {
-	_, _, backend := startTestBackend(t)
-
 	validWethDaiTx, validWethDaiTxTrace, invalidWethDaiTx, invalidWethDaiTrace := GetCustomDevnetTracingRelatedTestData(t)
 
 	cases := []struct {
@@ -174,7 +172,7 @@ func TestIsTxWEthDaiSwap(t *testing.T) {
 			callTraces:    validWethDaiTxTrace,
 			tx:            validWethDaiTx,
 			isTxCorrect:   true,
-			network:       "custom",
+			network:       common.EthNetworkCustom,
 			requiredError: "",
 		},
 		{
@@ -182,13 +180,15 @@ func TestIsTxWEthDaiSwap(t *testing.T) {
 			callTraces:    invalidWethDaiTrace,
 			tx:            invalidWethDaiTx,
 			isTxCorrect:   false,
-			network:       "custom",
+			network:       common.EthNetworkCustom,
 			requiredError: "",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
+			_, _, backend := startTestBackend(t, c.network)
+
 			// Payload attributes
 			parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, headSlot := GetTestPayloadAttributes(t)
 
@@ -208,12 +208,12 @@ func TestIsTxWEthDaiSwap(t *testing.T) {
 
 // this is only for custom network
 func TestIsTraceToWEthDaiPair(t *testing.T) {
-	_, _, backend := startTestBackend(t)
+	_, _, backend := startTestBackend(t, common.EthNetworkCustom)
 
 	// Payload attributes
 	parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, headSlot := GetTestPayloadAttributes(t)
 
-	prepareBackend(t, backend, headSlot, parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, "custom")
+	prepareBackend(t, backend, headSlot, parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, common.EthNetworkCustom)
 
 	wethDaiTraceContents := common.LoadFileContents(t, "../../testdata/traces/custom/weth_dai_trace.json")
 	wethDaiTrace := new(common.CallTrace)
@@ -278,7 +278,7 @@ func TestIsTraceToWEthDaiPair(t *testing.T) {
 }
 
 func TestNetworkIndependentCheckTxAndSenderValidity(t *testing.T) {
-	_, _, backend := startTestBackend(t)
+	_, _, backend := startTestBackend(t, common.EthNetworkCustom)
 	randomAddress := common2.BytesToAddress([]byte("0xabc"))
 
 	cases := []struct {
@@ -451,7 +451,7 @@ func TestNetworkIndependentCheckTxAndSenderValidity(t *testing.T) {
 }
 
 func TestCustomDevnetCheckTxAndSenderValidity(t *testing.T) {
-	_, _, backend := startTestBackend(t)
+	_, _, backend := startTestBackend(t, common.EthNetworkCustom)
 
 	validWethDaiTx, validWethDaiTxTrace, invalidWethDaiTx, invalidWethDaiTrace := GetCustomDevnetTracingRelatedTestData(t)
 
@@ -511,6 +511,8 @@ func TestCustomDevnetCheckTxAndSenderValidity(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
+			_, _, backend := startTestBackend(t, common.EthNetworkCustom)
+
 			backend.relay.tracer = &MockTracer{
 				tracerError: "",
 				callTrace:   c.callTraces,
@@ -518,7 +520,7 @@ func TestCustomDevnetCheckTxAndSenderValidity(t *testing.T) {
 
 			parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, headSlot := GetTestPayloadAttributes(t)
 
-			prepareBackend(t, backend, headSlot, parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, "custom")
+			prepareBackend(t, backend, headSlot, parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, common.EthNetworkCustom)
 
 			err := backend.relay.checkTxAndSenderValidity(c.txs, common.TestLog)
 			if c.requiredError != "" {
@@ -532,7 +534,7 @@ func TestCustomDevnetCheckTxAndSenderValidity(t *testing.T) {
 
 // tests when tob txs are sent in sequence
 func TestSubmitTobTxsInSequence(t *testing.T) {
-	backend := newTestBackend(t, 1)
+	backend := newTestBackend(t, 1, common.EthNetworkCustom)
 
 	_, validWethDaiTxTrace, _, _ := GetCustomDevnetTracingRelatedTestData(t)
 
@@ -585,7 +587,7 @@ func TestSubmitTobTxsInSequence(t *testing.T) {
 			},
 			firstTobTxsTraces:  validWethDaiTxTrace,
 			secondTobTxsTraces: validWethDaiTxTrace,
-			network:            "custom",
+			network:            common.EthNetworkCustom,
 			nextSentIsHigher:   true,
 		},
 		{
@@ -628,7 +630,7 @@ func TestSubmitTobTxsInSequence(t *testing.T) {
 			},
 			firstTobTxsTraces:  validWethDaiTxTrace,
 			secondTobTxsTraces: validWethDaiTxTrace,
-			network:            "custom",
+			network:            common.EthNetworkCustom,
 			nextSentIsHigher:   false,
 		},
 	}
@@ -636,7 +638,7 @@ func TestSubmitTobTxsInSequence(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 
-			backend := newTestBackend(t, 1)
+			backend := newTestBackend(t, 1, c.network)
 
 			parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, headSlot := GetTestPayloadAttributes(t)
 
@@ -707,7 +709,7 @@ func TestSubmitTobTxsInSequence(t *testing.T) {
 }
 
 func TestSubmitTobTxs(t *testing.T) {
-	backend := newTestBackend(t, 1)
+	backend := newTestBackend(t, 1, common.EthNetworkCustom)
 
 	_, validWethDaiTxTrace, _, invalidWethDaiTrace := GetCustomDevnetTracingRelatedTestData(t)
 
@@ -733,7 +735,7 @@ func TestSubmitTobTxs(t *testing.T) {
 			},
 			requiredError: "We require a payment tx along with the TOB txs!",
 			traces:        nil,
-			network:       "custom",
+			network:       common.EthNetworkCustom,
 			slotDelta:     1,
 		},
 		{
@@ -758,7 +760,7 @@ func TestSubmitTobTxs(t *testing.T) {
 			},
 			requiredError: "we require a payment tx to the relayer along with the TOB txs",
 			traces:        nil,
-			network:       "custom",
+			network:       common.EthNetworkCustom,
 			slotDelta:     1,
 		},
 		{
@@ -783,7 +785,7 @@ func TestSubmitTobTxs(t *testing.T) {
 			},
 			traces:        invalidWethDaiTrace,
 			requiredError: "not a valid tob tx",
-			network:       "custom",
+			network:       common.EthNetworkCustom,
 			slotDelta:     1,
 		},
 		{
@@ -808,14 +810,14 @@ func TestSubmitTobTxs(t *testing.T) {
 			},
 			traces:        nil,
 			requiredError: "Slot's TOB bid not yet started!!",
-			network:       "custom",
+			network:       common.EthNetworkCustom,
 			slotDelta:     2,
 		},
 		{
 			description:   "No txs sent",
 			tobTxs:        []*gethtypes.Transaction{},
 			requiredError: "Empty TOB tx request sent",
-			network:       "custom",
+			network:       common.EthNetworkCustom,
 			slotDelta:     1,
 			traces:        nil,
 		},
@@ -840,7 +842,7 @@ func TestSubmitTobTxs(t *testing.T) {
 				}),
 			},
 			traces:        validWethDaiTxTrace,
-			network:       "custom",
+			network:       common.EthNetworkCustom,
 			requiredError: "",
 			slotDelta:     1,
 		},
@@ -848,7 +850,7 @@ func TestSubmitTobTxs(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			backend := newTestBackend(t, 1)
+			backend := newTestBackend(t, 1, c.network)
 
 			parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, headSlot := GetTestPayloadAttributes(t)
 
@@ -948,7 +950,7 @@ func assertBlock(t *testing.T, backend *testBackend, headSlot uint64, parentHash
 }
 
 func TestSubmitBuilderBlockInSequence(t *testing.T) {
-	backend := newTestBackend(t, 1)
+	backend := newTestBackend(t, 1, common.EthNetworkCustom)
 
 	_, validWethDaiTxTrace, _, _ := GetCustomDevnetTracingRelatedTestData(t)
 
@@ -1001,7 +1003,7 @@ func TestSubmitBuilderBlockInSequence(t *testing.T) {
 			},
 			firstTobTxsTraces:  validWethDaiTxTrace,
 			secondTobTxsTraces: validWethDaiTxTrace,
-			network:            "custom",
+			network:            common.EthNetworkCustom,
 			nextSentIsHigher:   true,
 		},
 		{
@@ -1044,14 +1046,14 @@ func TestSubmitBuilderBlockInSequence(t *testing.T) {
 			},
 			firstTobTxsTraces:  validWethDaiTxTrace,
 			secondTobTxsTraces: validWethDaiTxTrace,
-			network:            "custom",
+			network:            common.EthNetworkCustom,
 			nextSentIsHigher:   false,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			backend := newTestBackend(t, 1)
+			backend := newTestBackend(t, 1, c.network)
 
 			parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, headSlot := GetTestPayloadAttributes(t)
 
@@ -1167,7 +1169,7 @@ func TestSubmitBuilderBlockInSequence(t *testing.T) {
 }
 
 func TestSubmitBuilderBlock(t *testing.T) {
-	backend := newTestBackend(t, 1)
+	backend := newTestBackend(t, 1, common.EthNetworkCustom)
 
 	validWethDaiTx, validWethDaiTxTrace, _, _ := GetCustomDevnetTracingRelatedTestData(t)
 
@@ -1175,12 +1177,14 @@ func TestSubmitBuilderBlock(t *testing.T) {
 		description   string
 		tobTxs        []*gethtypes.Transaction
 		traces        *common.CallTrace
+		network       string
 		requiredError string
 	}{
 		{
 			description:   "No ToB txs",
 			tobTxs:        []*gethtypes.Transaction{},
 			traces:        nil,
+			network:       common.EthNetworkCustom,
 			requiredError: "",
 		},
 		{
@@ -1203,6 +1207,7 @@ func TestSubmitBuilderBlock(t *testing.T) {
 					Data:     []byte(""),
 				}),
 			},
+			network:       common.EthNetworkCustom,
 			traces:        validWethDaiTxTrace,
 			requiredError: "",
 		},
@@ -1210,14 +1215,14 @@ func TestSubmitBuilderBlock(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			backend = newTestBackend(t, 1)
+			backend = newTestBackend(t, 1, c.network)
 
 			parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, headSlot := GetTestPayloadAttributes(t)
 
 			submissionSlot := headSlot + 1
 			submissionTimestamp := 1606824419
 
-			prepareBackend(t, backend, headSlot, parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, "custom")
+			prepareBackend(t, backend, headSlot, parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, common.EthNetworkCustom)
 
 			if c.traces != nil {
 				backend.relay.tracer = &MockTracer{

--- a/services/api/pepc_boost_test.go
+++ b/services/api/pepc_boost_test.go
@@ -194,7 +194,7 @@ func TestIsTxWEthDaiSwap(t *testing.T) {
 
 			prepareBackend(t, backend, headSlot, parentHash, feeRec, withdrawalsRoot, prevRandao, proposerPubkey, c.network)
 
-			res, err := backend.relay.IsTxWEthDaiSwap(c.callTraces)
+			res, err := backend.relay.StateInterferenceChecks(c.callTraces)
 			if c.requiredError != "" {
 				require.Contains(t, err.Error(), c.requiredError)
 			} else {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -265,17 +265,20 @@ func FillUpDefiAddresses(opts RelayAPIOpts) map[string]common2.Address {
 	if opts.EthNetDetails.Name == "mainnet" {
 		// TODO - fill up mainnet defi addresses
 	} else if opts.EthNetDetails.Name == "goerli" {
-		// TODO - fill up goerli addresses
+		defiAddresses[common.WethToken] = common2.HexToAddress("0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6")
+		defiAddresses[common.UsdcToken] = common2.HexToAddress("0x07865c6e87b9f70255377e024ace6630c1eaa37f")
+		defiAddresses[common.UniV3SwapRouter] = common2.HexToAddress("0x1F98431c8aD98523631AE4a59f267346ea31F984")
+	} else if opts.EthNetDetails.Name == "custom" {
+
+		defiAddresses[common.DaiToken] = common2.HexToAddress("0xAb2A01BC351770D09611Ac80f1DE076D56E0487d")
+		defiAddresses[common.WethToken] = common2.HexToAddress("0x4c849Ff66a6F0A954cbf7818b8a763105C2787D6")
+
+		// this is only in custom kurtosis devnets
+		defiAddresses[common.DaiWethPair1] = common2.HexToAddress("0x0D6b80a9Cefc2C58308F0Adc26586E550E4422ef")
+		defiAddresses[common.UniswapFactory1] = common2.HexToAddress("0xBFF5cD0aA560e1d1C6B1E2C347860aDAe1bd8235")
+		defiAddresses[common.DaiWethPair2] = common2.HexToAddress("0x2ed2B47342450C006F83913a422F7C2BDAB8377a")
+		defiAddresses[common.UniswapFactory2] = common2.HexToAddress("0x6bEaE43B589D986d127Bd2BdAcF4e24C41C5C035")
 	}
-
-	defiAddresses[common.DaiToken] = common2.HexToAddress("0xAb2A01BC351770D09611Ac80f1DE076D56E0487d")
-	defiAddresses[common.WethToken] = common2.HexToAddress("0x4c849Ff66a6F0A954cbf7818b8a763105C2787D6")
-
-	// this is only in custom kurtosis devnets
-	defiAddresses[common.DaiWethPair1] = common2.HexToAddress("0x0D6b80a9Cefc2C58308F0Adc26586E550E4422ef")
-	defiAddresses[common.UniswapFactory1] = common2.HexToAddress("0xBFF5cD0aA560e1d1C6B1E2C347860aDAe1bd8235")
-	defiAddresses[common.DaiWethPair2] = common2.HexToAddress("0x2ed2B47342450C006F83913a422F7C2BDAB8377a")
-	defiAddresses[common.UniswapFactory2] = common2.HexToAddress("0x6bEaE43B589D986d127Bd2BdAcF4e24C41C5C035")
 
 	return defiAddresses
 }

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -262,13 +262,13 @@ type RelayAPI struct {
 func FillUpDefiAddresses(opts RelayAPIOpts) map[string]common2.Address {
 	defiAddresses := make(map[string]common2.Address)
 
-	if opts.EthNetDetails.Name == "mainnet" {
+	if opts.EthNetDetails.Name == common.EthNetworkMainnet {
 		// TODO - fill up mainnet defi addresses
-	} else if opts.EthNetDetails.Name == "goerli" {
+	} else if opts.EthNetDetails.Name == common.EthNetworkGoerli {
 		defiAddresses[common.WethToken] = common2.HexToAddress("0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6")
-		defiAddresses[common.UsdcToken] = common2.HexToAddress("0x07865c6e87b9f70255377e024ace6630c1eaa37f")
+		defiAddresses[common.UsdcToken] = common2.HexToAddress("0x9B2660A7BEcd0Bf3d90401D1C214d2CD36317da5")
 		defiAddresses[common.UniV3SwapRouter] = common2.HexToAddress("0x1F98431c8aD98523631AE4a59f267346ea31F984")
-	} else if opts.EthNetDetails.Name == "custom" {
+	} else if opts.EthNetDetails.Name == common.EthNetworkCustom {
 
 		defiAddresses[common.DaiToken] = common2.HexToAddress("0xAb2A01BC351770D09611Ac80f1DE076D56E0487d")
 		defiAddresses[common.WethToken] = common2.HexToAddress("0x4c849Ff66a6F0A954cbf7818b8a763105C2787D6")
@@ -618,9 +618,9 @@ func (api *RelayAPI) startValidatorRegistrationDBProcessor() {
 
 // TODO - come up with better name? state interference is not really descriptive name
 func (api *RelayAPI) StateInterferenceChecks(trace *common.CallTrace) (bool, error) {
-	if api.opts.EthNetDetails.Name == "custom" {
+	if api.opts.EthNetDetails.Name == common.EthNetworkCustom {
 		return api.TraceChecker(trace, api.IsTraceToWEthDaiPair)
-	} else if api.opts.EthNetDetails.Name == "goerli" {
+	} else if api.opts.EthNetDetails.Name == common.EthNetworkGoerli {
 		return api.TraceChecker(trace, api.IsTraceUniV3EthUsdcSwap)
 	}
 
@@ -639,7 +639,6 @@ func (api *RelayAPI) TraceChecker(trace *common.CallTrace, f common.NetworkState
 		if err != nil {
 			return false, err
 		}
-		// we found a weth/dai swap i.e the tx contains a weth/dai swap
 		if res {
 			return true, nil
 		}
@@ -683,6 +682,7 @@ func (api *RelayAPI) IsTraceUniV3EthUsdcSwap(callTrace common.CallTrace) (bool, 
 	if err != nil {
 		return false, err
 	}
+	// TODO - we should support other uniswap smart contract calls. Support one for now.
 	exactInputSingleId := uniV3SwapRouterAbi.Methods["exactInputSingle"].ID
 	if !bytes.Equal(callTrace.Input[:4], exactInputSingleId) {
 		return false, nil

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -693,14 +693,17 @@ func (api *RelayAPI) IsTraceUniV3EthUsdcSwap(callTrace common.CallTrace) (bool, 
 	if err != nil {
 		return false, err
 	}
-	swapRouterParams, ok := args.(contracts.ISwapRouterExactInputSingleParams)
-	if !ok {
-		return false, fmt.Errorf("failed to parse args of swapRouter tx to ISwapRouterExactInputSingleParams")
+	// TODO - this is inefficient, i was not able to cast the interface to the struct for some reason. re-visit this later
+	argBytes, err := json.Marshal(args)
+	swapRouterParams := new(contracts.ISwapRouterExactInputSingleParams)
+	err = json.Unmarshal(argBytes, swapRouterParams)
+	if err != nil {
+		return false, err
 	}
-	if swapRouterParams.TokenIn != api.defiAddresses[common.WethToken] || swapRouterParams.TokenOut != api.defiAddresses[common.UsdcToken] {
+	if swapRouterParams.TokenIn != api.defiAddresses[common.WethToken] && swapRouterParams.TokenIn != api.defiAddresses[common.UsdcToken] {
 		return false, nil
 	}
-	if swapRouterParams.TokenOut != api.defiAddresses[common.UsdcToken] || swapRouterParams.TokenOut != api.defiAddresses[common.WethToken] {
+	if swapRouterParams.TokenOut != api.defiAddresses[common.UsdcToken] && swapRouterParams.TokenOut != api.defiAddresses[common.WethToken] {
 		return false, nil
 	}
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -267,7 +267,7 @@ func FillUpDefiAddresses(opts RelayAPIOpts) map[string]common2.Address {
 	} else if opts.EthNetDetails.Name == common.EthNetworkGoerli {
 		defiAddresses[common.WethToken] = common2.HexToAddress("0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6")
 		defiAddresses[common.UsdcToken] = common2.HexToAddress("0x9B2660A7BEcd0Bf3d90401D1C214d2CD36317da5")
-		defiAddresses[common.UniV3SwapRouter] = common2.HexToAddress("0x1F98431c8aD98523631AE4a59f267346ea31F984")
+		defiAddresses[common.UniV3SwapRouter] = common2.HexToAddress("0xE592427A0AEce92De3Edee1F18E0157C05861564")
 	} else if opts.EthNetDetails.Name == common.EthNetworkCustom {
 
 		defiAddresses[common.DaiToken] = common2.HexToAddress("0xAb2A01BC351770D09611Ac80f1DE076D56E0487d")


### PR DESCRIPTION
## 📝 Summary

For goerli n/w, we are checking if the ToB tx is a uniswap v3 eth/usdc tx. We add state interference checks to check if the ToB tx is a uniswap v3 eth/usdc tx. In this PR, we add types and methods required to prepare for this check.

It works in the same as mentioned in https://github.com/bharath-123/pepc-boost-relay/pull/15 

For goerli, we check if the tx is a valid uniswap v3 eth/usdc swap. To do this we check if the tx is sent to the swap router with tokenIn and tokenOut as the Eth and Usdc token addresses.