### PR TITLE
Simulate the RoB block if there are no ToB txs present in the slot

### DIFF
--- a/services/api/pepc_boost_test.go
+++ b/services/api/pepc_boost_test.go
@@ -1768,6 +1768,10 @@ func TestSubmitBuilderBlock(t *testing.T) {
 				payoutTxs := c.tobTxs[len(c.tobTxs)-1]
 				tobTxsValue = payoutTxs.Value()
 				assertTobTxs(t, backend, headSlot+1, parentHash, tobTxsValue, txsHashRoot)
+			} else {
+				backend.relay.blockSimRateLimiter = &MockBlockSimulationRateLimiter{
+					simulationError: nil,
+				}
 			}
 
 			// Prepare the request payload


### PR DESCRIPTION
Currently, If there are no ToB txs present for a given slot, when a builder submits a RoB block we send it to the assembler with no ToB txs. The assembler correctly resolves to the final builder block but this activity can be a waste since validating a block is much cheaper than building one. So to optimize the submitBuilder path, if there are no ToB txs we just simulate the RoB rather then assembling it.