### PR TITLE
Add more robust ToB tx checks

### DIFF
--- a/services/api/ec_client.go
+++ b/services/api/ec_client.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"context"
+	"math/big"
+
+	common2 "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+type IEcClient interface {
+	GetLatestNonce(address common2.Address) (uint64, error)
+	GetLatestBalance(address common2.Address) (*big.Int, error)
+}
+
+type EcClient struct {
+	ecClient *ethclient.Client
+}
+
+func NewEcClient(ecUrl string) (*EcClient, error) {
+	ecClient, err := ethclient.Dial(ecUrl)
+	if err != nil {
+		return nil, err
+	}
+	return &EcClient{ecClient: ecClient}, nil
+}
+
+func (ec *EcClient) GetLatestNonce(address common2.Address) (uint64, error) {
+	return ec.ecClient.NonceAt(context.Background(), address, nil)
+}
+
+func (ec *EcClient) GetLatestBalance(address common2.Address) (*big.Int, error) {
+	return ec.ecClient.BalanceAt(context.Background(), address, nil)
+}

--- a/services/api/ec_client.go
+++ b/services/api/ec_client.go
@@ -5,12 +5,14 @@ import (
 	"math/big"
 
 	common2 "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 type IEcClient interface {
 	GetLatestNonce(address common2.Address) (uint64, error)
 	GetLatestBalance(address common2.Address) (*big.Int, error)
+	GetSigner(tx *types.Transaction) (common2.Address, error)
 }
 
 type EcClient struct {
@@ -31,4 +33,8 @@ func (ec *EcClient) GetLatestNonce(address common2.Address) (uint64, error) {
 
 func (ec *EcClient) GetLatestBalance(address common2.Address) (*big.Int, error) {
 	return ec.ecClient.BalanceAt(context.Background(), address, nil)
+}
+
+func (ec *EcClient) GetSigner(tx *types.Transaction) (common2.Address, error) {
+	return types.Sender(types.NewCancunSigner(tx.ChainId()), tx)
 }

--- a/services/api/mock_ec_client.go
+++ b/services/api/mock_ec_client.go
@@ -3,21 +3,21 @@ package api
 import "math/big"
 
 type MockEcClient struct {
-	Nonce   uint64
-	Balance *big.Int
+	nonceMap   map[string]uint64
+	balanceMap map[string]*big.Int
 }
 
-func NewMockEcClient(nonce uint64, balance *big.Int) *MockEcClient {
+func NewMockEcClient(nonceMap map[string]uint64, balanceMap map[string]*big.Int) *MockEcClient {
 	return &MockEcClient{
-		Nonce:   nonce,
-		Balance: balance,
+		nonceMap:   nonceMap,
+		balanceMap: balanceMap,
 	}
 }
 
 func (ec *MockEcClient) GetLatestNonce(address string) (uint64, error) {
-	return ec.Nonce, nil
+	return ec.nonceMap[address], nil
 }
 
 func (ec *MockEcClient) GetLatestBalance(address string) (*big.Int, error) {
-	return ec.Balance, nil
+	return ec.balanceMap[address], nil
 }

--- a/services/api/mock_ec_client.go
+++ b/services/api/mock_ec_client.go
@@ -1,0 +1,23 @@
+package api
+
+import "math/big"
+
+type MockEcClient struct {
+	Nonce   uint64
+	Balance *big.Int
+}
+
+func NewMockEcClient(nonce uint64, balance *big.Int) *MockEcClient {
+	return &MockEcClient{
+		Nonce:   nonce,
+		Balance: balance,
+	}
+}
+
+func (ec *MockEcClient) GetLatestNonce(address string) (uint64, error) {
+	return ec.Nonce, nil
+}
+
+func (ec *MockEcClient) GetLatestBalance(address string) (*big.Int, error) {
+	return ec.Balance, nil
+}

--- a/services/api/mock_ec_client.go
+++ b/services/api/mock_ec_client.go
@@ -1,16 +1,22 @@
 package api
 
-import "math/big"
+import (
+	"math/big"
+
+	common2 "github.com/ethereum/go-ethereum/common"
+)
 
 type MockEcClient struct {
 	nonceMap   map[string]uint64
 	balanceMap map[string]*big.Int
+	sender     common2.Address
 }
 
-func NewMockEcClient(nonceMap map[string]uint64, balanceMap map[string]*big.Int) *MockEcClient {
+func NewMockEcClient(nonceMap map[string]uint64, balanceMap map[string]*big.Int, sender common2.Address) *MockEcClient {
 	return &MockEcClient{
 		nonceMap:   nonceMap,
 		balanceMap: balanceMap,
+		sender:     sender,
 	}
 }
 
@@ -20,4 +26,8 @@ func (ec *MockEcClient) GetLatestNonce(address string) (uint64, error) {
 
 func (ec *MockEcClient) GetLatestBalance(address string) (*big.Int, error) {
 	return ec.balanceMap[address], nil
+}
+
+func (ec *MockEcClient) GetSigner() (common2.Address, error) {
+	return ec.sender, nil
 }


### PR DESCRIPTION
## 📝 Summary

Add robust tx checks like checking for the sender's nonce and balance. We also check the traces to check if the root tx has reverted.