### PR TITLE
[PEPC-Boost] Integrate submit ToB txs api with Tob validation RPC

### DIFF
--- a/services/api/mock_blocksim_ratelimiter.go
+++ b/services/api/mock_blocksim_ratelimiter.go
@@ -7,11 +7,16 @@ import (
 )
 
 type MockBlockSimulationRateLimiter struct {
-	simulationError error
+	simulationError    error
+	tobSimulationError error
 }
 
 func (m *MockBlockSimulationRateLimiter) Send(context context.Context, payload *common.BuilderBlockValidationRequest, isHighPrio, fastTrack bool) (error, error) {
 	return nil, m.simulationError
+}
+
+func (m *MockBlockSimulationRateLimiter) TobSim(context context.Context, tobValidationRequest *common.TobValidationRequest) (error, error) {
+	return nil, m.tobSimulationError
 }
 
 func (m *MockBlockSimulationRateLimiter) CurrentCounter() int64 {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -2010,7 +2010,7 @@ func (api *RelayAPI) handleSubmitNewTobTxs(w http.ResponseWriter, req *http.Requ
 		api.Respond(w, http.StatusBadRequest, "Empty TOB tx request sent!")
 		return
 	}
-	//
+
 	if slot < headSlot {
 		log.Error("TOB tx request for past slot!")
 		api.Respond(w, http.StatusBadRequest, "Submitted TOB tx request for past slot!")


### PR DESCRIPTION
## 📝 Summary

We are now using the TOB validation RPC implemented in the builder here: https://github.com/bharath-123/pepc-boost-builder/pull/15  to validate TOB txs submitted by the searchers. This is a more robust TOB validation compared to what we previously had.

In this PR we integrate the TOB validation RPC in the submit TOB txs flow

Resolves https://github.com/bharath-123/pepc-boost-relay/issues/21