### PR TITLE
Store included ToB txs for book keeping

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -81,7 +81,7 @@ var (
 	pathDataProposerPayloadDelivered = "/relay/v1/data/bidtraces/proposer_payload_delivered"
 	pathDataBuilderBidsReceived      = "/relay/v1/data/bidtraces/builder_blocks_received"
 	pathDataValidatorRegistration    = "/relay/v1/data/validator_registration"
-	pathIncludedTobTxs               = "/relay/v1/data/included_tob_txs"
+	pathIncludedTobTxs               = "/relay/v1/data/included_tob_txs/{slot:[0-9]+}/{parent_hash:0x[a-fA-F0-9]+}/{block_hash:0x[a-fA-F0-9]+}"
 
 	// Internal API
 	pathInternalBuilderStatus     = "/internal/v1/builder/{pubkey:0x[a-fA-F0-9]+}"


### PR DESCRIPTION
## 📝 Summary

We currently have no idea if a ToB tx has indeed been included in a block or not since a ToB tx only is stored for 45s in the redis cache. We add a new postgres table which persists the ToB txs that have been included in a full block. This covers all assembled blocks and not just blocks which have been proposed.