### PR TITLE
[PEPC-Boost] Redis types for multi slot ToB auction

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -54,6 +54,8 @@ var (
 	UniswapFactory1 = "uniswap_factory_1"
 	UniswapFactory2 = "uniswap_factory_2"
 	UniV3SwapRouter = "uniswap_v3_swap_router"
+
+	MaxTobSlots = 3
 )
 
 type EthNetworkDetails struct {

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -153,12 +153,12 @@ func NewRedisCache(prefix, redisURI, readonlyURI string) (*RedisCache, error) {
 	}, nil
 }
 
-func (r *RedisCache) keyCacheGetTobTxs(slot uint64, parentHash string) string {
-	return fmt.Sprintf("%s:%d-%s", r.prefixTobTobTx, slot, parentHash)
+func (r *RedisCache) keyCacheGetTobTxs(slot uint64, parentHash string, tobSlotId uint64) string {
+	return fmt.Sprintf("%s:%d-%s-%d", r.prefixTobTobTx, slot, parentHash, tobSlotId)
 }
 
-func (r *RedisCache) keyCacheGetTobTxsValue(slot uint64, parentHash string) string {
-	return fmt.Sprintf("%s:%d-%s", r.prefixTopTobTxValue, slot, parentHash)
+func (r *RedisCache) keyCacheGetTobTxsValue(slot uint64, parentHash string, tobSlotId uint64) string {
+	return fmt.Sprintf("%s:%d-%s-%d", r.prefixTopTobTxValue, slot, parentHash, tobSlotId)
 }
 
 func (r *RedisCache) keyCacheGetHeaderResponse(slot uint64, parentHash, proposerPubkey string) string {
@@ -374,8 +374,8 @@ func (r *RedisCache) GetBestBid(slot uint64, parentHash, proposerPubkey string) 
 	return resp, err
 }
 
-func (r *RedisCache) SetTobTx(ctx context.Context, tx redis.Pipeliner, slot uint64, parentHash string, txs [][]byte) error {
-	key := r.keyCacheGetTobTxs(slot, parentHash)
+func (r *RedisCache) SetTobTx(ctx context.Context, tx redis.Pipeliner, slot uint64, parentHash string, tobSlotId uint64, txs [][]byte) error {
+	key := r.keyCacheGetTobTxs(slot, parentHash, tobSlotId)
 	finalTxStrings := []string{}
 	for _, tx := range txs {
 		finalTxStrings = append(finalTxStrings, hex.EncodeToString(tx))
@@ -390,8 +390,8 @@ func (r *RedisCache) SetTobTx(ctx context.Context, tx redis.Pipeliner, slot uint
 	return err
 }
 
-func (r *RedisCache) GetTobTx(ctx context.Context, tx redis.Pipeliner, slot uint64, parentHash string) ([][]byte, error) {
-	key := r.keyCacheGetTobTxs(slot, parentHash)
+func (r *RedisCache) GetTobTx(ctx context.Context, tx redis.Pipeliner, slot uint64, parentHash string, tobSlotId uint64) ([][]byte, error) {
+	key := r.keyCacheGetTobTxs(slot, parentHash, tobSlotId)
 	resp := make([][]byte, 0)
 	c := tx.Get(ctx, key)
 	_, err := tx.Exec(ctx)
@@ -416,8 +416,8 @@ func (r *RedisCache) GetTobTx(ctx context.Context, tx redis.Pipeliner, slot uint
 	return resp, err
 }
 
-func (r *RedisCache) SetTobTxValue(ctx context.Context, tx redis.Pipeliner, value *big.Int, slot uint64, parentHash string) (err error) {
-	key := r.keyCacheGetTobTxsValue(slot, parentHash)
+func (r *RedisCache) SetTobTxValue(ctx context.Context, tx redis.Pipeliner, value *big.Int, slot uint64, parentHash string, tobSlotId uint64) (err error) {
+	key := r.keyCacheGetTobTxsValue(slot, parentHash, tobSlotId)
 	err = tx.Set(ctx, key, value.String(), expiryBidCache).Err()
 	if err != nil {
 		return err
@@ -426,8 +426,8 @@ func (r *RedisCache) SetTobTxValue(ctx context.Context, tx redis.Pipeliner, valu
 	return err
 }
 
-func (r *RedisCache) GetTobTxValue(ctx context.Context, tx redis.Pipeliner, slot uint64, parentHash string) (tobTxValue *big.Int, err error) {
-	keyTobTxValue := r.keyCacheGetTobTxsValue(slot, parentHash)
+func (r *RedisCache) GetTobTxValue(ctx context.Context, tx redis.Pipeliner, slot uint64, parentHash string, tobSlotId uint64) (tobTxValue *big.Int, err error) {
+	keyTobTxValue := r.keyCacheGetTobTxsValue(slot, parentHash, tobSlotId)
 	c := tx.Get(ctx, keyTobTxValue)
 	_, err = tx.Exec(ctx)
 	if errors.Is(err, redis.Nil) {

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -519,7 +519,7 @@ func TestSetTobTxs(t *testing.T) {
 
 	// Get the TOB txs
 	_, err := cache.client.TxPipelined(context.Background(), func(tx redis.Pipeliner) error {
-		b, err := cache.GetTobTx(context.Background(), tx, slot, parentHash)
+		b, err := cache.GetTobTx(context.Background(), tx, slot, parentHash, 0)
 		require.NoError(t, err)
 		require.Equal(t, b, [][]byte{})
 		return nil
@@ -554,14 +554,18 @@ func TestSetTobTxs(t *testing.T) {
 	}
 
 	_, err = cache.client.TxPipelined(context.Background(), func(tx redis.Pipeliner) error {
-		return cache.SetTobTx(context.Background(), tx, slot, parentHash, txs.Transactions)
+		return cache.SetTobTx(context.Background(), tx, slot, parentHash, 0, txs.Transactions)
 	})
 	require.NoError(t, err)
 
 	_, err = cache.client.TxPipelined(context.Background(), func(tx redis.Pipeliner) error {
-		b, err := cache.GetTobTx(context.Background(), tx, slot, parentHash)
+		b, err := cache.GetTobTx(context.Background(), tx, slot, parentHash, 0)
 		require.NoError(t, err)
 		require.Equal(t, b, txs.Transactions)
+		b, err = cache.GetTobTx(context.Background(), tx, slot, parentHash, 1)
+		require.NoError(t, err)
+		require.Equal(t, b, [][]byte{})
+
 		return nil
 	})
 }
@@ -575,15 +579,27 @@ func TestSetTobTxValue(t *testing.T) {
 	// Set a value
 	value := big.NewInt(123)
 	_, err := cache.client.TxPipelined(context.Background(), func(tx redis.Pipeliner) error {
-		v, err := cache.GetTobTxValue(context.Background(), tx, slot, parentHash)
+		v, err := cache.GetTobTxValue(context.Background(), tx, slot, parentHash, 0)
 		require.NoError(t, err)
 		require.Equal(t, v, big.NewInt(0))
 
-		err = cache.SetTobTxValue(context.Background(), tx, value, slot, parentHash)
+		err = cache.SetTobTxValue(context.Background(), tx, value, slot, parentHash, 0)
 		require.NoError(t, err)
 
 		// Get the value back
-		v, err = cache.GetTobTxValue(context.Background(), tx, slot, parentHash)
+		v, err = cache.GetTobTxValue(context.Background(), tx, slot, parentHash, 0)
+		require.NoError(t, err)
+		require.Equal(t, v, big.NewInt(123))
+
+		v, err = cache.GetTobTxValue(context.Background(), tx, slot, parentHash, 1)
+		require.NoError(t, err)
+		require.Equal(t, v, big.NewInt(0))
+
+		err = cache.SetTobTxValue(context.Background(), tx, value, slot, parentHash, 1)
+		require.NoError(t, err)
+
+		// Get the value back
+		v, err = cache.GetTobTxValue(context.Background(), tx, slot, parentHash, 1)
 		require.NoError(t, err)
 		require.Equal(t, v, big.NewInt(123))
 


### PR DESCRIPTION
## 📝 Summary

Add the redis types for a multi-slot ToB auction. We are doing 2 things:
1. Defining a Max slot limit which is 3 for now
2. Appending redis keys with a slot id to namespace the slot txs in redis 