### PR TITLE
[PEPC-Boost] Parallel Multi Slot ToB auction implementation

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -55,7 +55,7 @@ var (
 	UniswapFactory2 = "uniswap_factory_2"
 	UniV3SwapRouter = "uniswap_v3_swap_router"
 
-	MaxTobSlots = 3
+	MaxTobSlots = uint64(3)
 )
 
 type EthNetworkDetails struct {


### PR DESCRIPTION
## 📝 Summary

In this PR, we implement a parallel multi-slot ToB auction. Searchers can specify the slot within the ToB where they want their TX to be included. A separate auction fills each ToB slot. Currently, each slot accepts the same ToB swap specified before like a Eth/usdc uni v3 swap in Goerli and a Weth/Dai uni v2 swap in devnet.