### PR TITLE
[PEPC-Boost] add API to return ToB gas reservations

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -54,6 +54,8 @@ var (
 	UniswapFactory1 = "uniswap_factory_1"
 	UniswapFactory2 = "uniswap_factory_2"
 	UniV3SwapRouter = "uniswap_v3_swap_router"
+
+	TobGasReservations = 1000000
 )
 
 type EthNetworkDetails struct {

--- a/common/types.go
+++ b/common/types.go
@@ -966,12 +966,14 @@ type TobValidationRequest struct {
 	TobTxs               utilbellatrix.ExecutionPayloadTransactions
 	ParentHash           string
 	ProposerFeeRecipient string
+	TobGasLimit          uint64
 }
 
 type IntermediateTobValidationRequest struct {
 	TobTxs               []byte `json:"tob_txs"`
 	ParentHash           string `json:"parent_hash"`
 	ProposerFeeRecipient string `json:"proposer_fee_recipient"`
+	TobGasLimit          uint64 `json:"tob_gas_limit,string"`
 }
 
 func (t *TobValidationRequest) MarshalJson() ([]byte, error) {
@@ -984,6 +986,7 @@ func (t *TobValidationRequest) MarshalJson() ([]byte, error) {
 		TobTxs:               sszedTobTxs,
 		ParentHash:           t.ParentHash,
 		ProposerFeeRecipient: t.ProposerFeeRecipient,
+		TobGasLimit:          t.TobGasLimit,
 	}
 
 	return json.Marshal(intermediateStruct)
@@ -1001,6 +1004,8 @@ func (t *TobValidationRequest) UnmarshalJson(data []byte) error {
 		return err
 	}
 	t.ParentHash = intermediateJson.ParentHash
+	t.ProposerFeeRecipient = intermediateJson.ProposerFeeRecipient
+	t.TobGasLimit = intermediateJson.TobGasLimit
 
 	return nil
 }

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -73,10 +73,11 @@ var (
 	pathGetPayload        = "/eth/v1/builder/blinded_blocks"
 
 	// Block builder API
-	pathBuilderGetValidators = "/relay/v1/builder/validators"
-	pathSubmitNewBlock       = "/relay/v1/builder/blocks"
-	pathSubmitNewRobBlock    = "/relay/v1/builder/rob_blocks"
-	pathSubmitNewTobTxs      = "/relay/v1/builder/tob_txs"
+	pathBuilderGetValidators  = "/relay/v1/builder/validators"
+	pathSubmitNewBlock        = "/relay/v1/builder/blocks"
+	pathSubmitNewRobBlock     = "/relay/v1/builder/rob_blocks"
+	pathSubmitNewTobTxs       = "/relay/v1/builder/tob_txs"
+	pathGetTobGasReservations = "/relay/v1/builder/tob_gas_reservations"
 
 	// Data API
 	pathDataProposerPayloadDelivered = "/relay/v1/data/bidtraces/proposer_payload_delivered"
@@ -425,6 +426,7 @@ func (api *RelayAPI) getRouter() http.Handler {
 		r.HandleFunc(pathSubmitNewBlock, api.handleSubmitNewBlock).Methods(http.MethodPost)
 		r.HandleFunc(pathSubmitNewRobBlock, api.handleSubmitNewRobBlock).Methods(http.MethodPost)
 		r.HandleFunc(pathSubmitNewTobTxs, api.handleSubmitNewTobTxs).Methods(http.MethodPost)
+		r.HandleFunc(pathGetTobGasReservations, api.).Methods(http.MethodGet)
 	}
 
 	// Data API
@@ -1943,6 +1945,10 @@ func (api *RelayAPI) checkTobTxsStateInterference(txs []*types.Transaction, log 
 	}
 
 	return nil
+}
+
+func (api *RelayAPI) handleGetTobGasReservations(w http.ResponseWriter, req *http.Request) {
+	api.RespondOK(w, common.TobGasReservations)
 }
 
 func (api *RelayAPI) handleSubmitNewTobTxs(w http.ResponseWriter, req *http.Request) {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -2771,7 +2771,7 @@ func (api *RelayAPI) handleSubmitNewRobBlock(w http.ResponseWriter, req *http.Re
 				return
 			}
 			for _, tx := range txs {
-				err := api.db.InsertIncludedTobTx(tx.Hash().String(), payload.Slot(), payload.ParentHash(), payload.BlockHash())
+				err := api.db.InsertIncludedTobTx(tx.Hash().String(), payload.Slot(), payload.ParentHash(), res.assembledPayload.BlockHash())
 				if err != nil {
 					log.WithError(err).Warn("could not insert included tob tx")
 					return
@@ -2902,6 +2902,7 @@ func (api *RelayAPI) handleSubmitNewRobBlock(w http.ResponseWriter, req *http.Re
 
 		// Simulate block (synchronously).
 		requestErr, validationErr := api.simulateBlock(context.Background(), opts) // success/error logging happens inside
+		log.Infof("DEBUG: Simulating block hash %s", payload.BlockHash())
 		simResultC <- &blockSimResult{requestErr == nil, false, requestErr, validationErr}
 		validationDurationMs := time.Since(timeBeforeValidation).Milliseconds()
 		log = log.WithFields(logrus.Fields{
@@ -2927,6 +2928,7 @@ func (api *RelayAPI) handleSubmitNewRobBlock(w http.ResponseWriter, req *http.Re
 
 	// Prepare the response data
 	getHeaderResponse, err := common.BuildGetHeaderResponse(builderSubmission, api.blsSk, api.publicKey, api.opts.EthNetDetails.DomainBuilder)
+	log.Infof("DEBUG: Blockhash in getHeaderResponse is %s\n", getHeaderResponse.BlockHash())
 	if err != nil {
 		log.WithError(err).Error("could not sign builder bid")
 		api.RespondError(w, http.StatusBadRequest, err.Error())

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -2043,6 +2043,7 @@ func (api *RelayAPI) handleSubmitNewTobTxs(w http.ResponseWriter, req *http.Requ
 			TobTxs:               tobTxRequest.TobTxs,
 			ParentHash:           tobTxRequest.ParentHash,
 			ProposerFeeRecipient: validatorFeeRecipient.String(),
+			TobGasLimit:          uint64(common.TobGasReservations),
 		},
 	})
 	if err != nil {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -2890,7 +2890,7 @@ func (api *RelayAPI) handleSubmitNewRobBlock(w http.ResponseWriter, req *http.Re
 			builder:    builderEntry,
 			req: &common.BuilderBlockValidationRequest{
 				BuilderSubmitBlockRequest: *payload,
-				RegisteredGasLimit:        gasLimit,
+				RegisteredGasLimit:        gasLimit - uint64(common.TobGasReservations),
 			},
 		}
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -426,7 +426,7 @@ func (api *RelayAPI) getRouter() http.Handler {
 		r.HandleFunc(pathSubmitNewBlock, api.handleSubmitNewBlock).Methods(http.MethodPost)
 		r.HandleFunc(pathSubmitNewRobBlock, api.handleSubmitNewRobBlock).Methods(http.MethodPost)
 		r.HandleFunc(pathSubmitNewTobTxs, api.handleSubmitNewTobTxs).Methods(http.MethodPost)
-		r.HandleFunc(pathGetTobGasReservations, api.).Methods(http.MethodGet)
+		r.HandleFunc(pathGetTobGasReservations, api.handleGetTobGasReservations).Methods(http.MethodGet)
 	}
 
 	// Data API


### PR DESCRIPTION
## 📝 Summary

Add an API to return the number of gas units reserved for the ToB. RoB builders can read this value and build blocks with gas limit of `validator_registration.gas_limit - tob_gas_reservations`