### PR TITLE
Faheel/v2 get payload

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -78,6 +78,7 @@ var (
 	pathRegisterValidator = "/eth/v1/builder/validators"
 	pathGetHeader         = "/eth/v1/builder/header/{slot:[0-9]+}/{parent_hash:0x[a-fA-F0-9]+}/{pubkey:0x[a-fA-F0-9]+}"
 	pathGetPayload        = "/eth/v1/builder/blinded_blocks"
+	pathGetPayloadV2      = "/eth/v2/builder/blinded_blocks"
 
 	// Block builder API
 	pathBuilderGetValidators = "/relay/v1/builder/validators"
@@ -367,6 +368,7 @@ func (api *RelayAPI) getRouter() http.Handler {
 		r.HandleFunc(pathRegisterValidator, api.handleRegisterValidator).Methods(http.MethodPost)
 		r.HandleFunc(pathGetHeader, api.handleGetHeader).Methods(http.MethodGet)
 		r.HandleFunc(pathGetPayload, api.handleGetPayload).Methods(http.MethodPost)
+		r.HandleFunc(pathGetPayloadV2, api.handleGetPayloadV2).Methods(http.MethodPost)
 	}
 
 	// Builder API
@@ -1362,6 +1364,7 @@ func (api *RelayAPI) checkProposerSignature(block *common.VersionedSignedBlinded
 	}
 }
 
+// Depreciated: Use handleGetPayloadV2. For more info visit: https://github.com/ethereum/builder-specs/issues/119
 func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) {
 	api.getPayloadCallsInFlight.Add(1)
 	defer api.getPayloadCallsInFlight.Done()
@@ -1743,6 +1746,401 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 		log.Debug("responding with JSON")
 		api.RespondOK(w, getPayloadResp)
 	}
+	blockNumber, err := payload.ExecutionBlockNumber()
+	if err != nil {
+		log.WithError(err).Info("failed to get block number")
+	}
+	txs, err := getPayloadResp.Transactions()
+	if err != nil {
+		log.WithError(err).Info("failed to get transactions")
+	}
+	log = log.WithFields(logrus.Fields{
+		"numTx":       len(txs),
+		"blockNumber": blockNumber,
+	})
+	if getPayloadResp.Version >= spec.DataVersionDeneb {
+		blobs, err := getPayloadResp.Blobs()
+		if err != nil {
+			log.WithError(err).Info("failed to get blobs")
+		}
+		blobGasUsed, err := getPayloadResp.BlobGasUsed()
+		if err != nil {
+			log.WithError(err).Info("failed to get blobGasUsed")
+		}
+		excessBlobGas, err := getPayloadResp.ExcessBlobGas()
+		if err != nil {
+			log.WithError(err).Info("failed to get excessBlobGas")
+		}
+		log = log.WithFields(logrus.Fields{
+			"numBlobs":      len(blobs),
+			"blobGasUsed":   blobGasUsed,
+			"excessBlobGas": excessBlobGas,
+		})
+	}
+	log.Info("execution payload delivered")
+}
+
+func (api *RelayAPI) handleGetPayloadV2(w http.ResponseWriter, req *http.Request) {
+	api.getPayloadCallsInFlight.Add(1)
+	defer api.getPayloadCallsInFlight.Done()
+
+	// Determine what encoding the proposer sent
+	proposerContentType := req.Header.Get(HeaderContentType)
+	proposerContentType, _, err := mime.ParseMediaType(proposerContentType)
+	if err != nil {
+		api.log.WithError(err).Error("failed to parse proposer content type")
+		api.RespondError(w, http.StatusUnsupportedMediaType, err.Error())
+		return
+	}
+
+	// Get the optional consensus version
+	proposerEthConsensusVersion := req.Header.Get("Eth-Consensus-Version")
+
+	ua := req.UserAgent()
+	headSlot := api.headSlot.Load()
+	receivedAt := time.Now().UTC()
+	log := api.log.WithFields(logrus.Fields{
+		"method":                      "getPayload",
+		"ua":                          ua,
+		"mevBoostV":                   common.GetMevBoostVersionFromUserAgent(ua),
+		"contentLength":               req.ContentLength,
+		"headSlot":                    headSlot,
+		"headSlotEpochPos":            (headSlot % common.SlotsPerEpoch) + 1,
+		"idArg":                       req.URL.Query().Get("id"),
+		"timestampRequestStart":       receivedAt.UnixMilli(),
+		"proposerContentType":         proposerContentType,
+		"proposerEthConsensusVersion": proposerEthConsensusVersion,
+	})
+
+	// Log at start and end of request
+	log.Info("request initiated")
+	defer func() {
+		log.WithFields(logrus.Fields{
+			"timestampRequestFin": time.Now().UTC().UnixMilli(),
+			"requestDurationMs":   time.Since(receivedAt).Milliseconds(),
+		}).Info("request finished")
+
+		metrics.GetPayloadLatencyHistogram.Record(
+			req.Context(),
+			float64(time.Since(receivedAt).Milliseconds()),
+		)
+	}()
+
+	// Read the body first, so we can decode it later
+	limitReader := io.LimitReader(req.Body, int64(apiMaxPayloadBytes))
+	body, err := io.ReadAll(limitReader)
+	if err != nil {
+		if strings.Contains(err.Error(), "i/o timeout") {
+			log.WithError(err).Error("getPayload request failed to decode (i/o timeout)")
+			api.RespondError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		log.WithError(err).Error("could not read body of request from the beacon node")
+		api.RespondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Decode payload
+	payload := new(common.VersionedSignedBlindedBeaconBlock)
+	err = payload.Unmarshal(body, proposerContentType, proposerEthConsensusVersion)
+	if err != nil {
+		log.WithError(err).Warn("failed to decode getPayload request")
+		api.RespondError(w, http.StatusBadRequest, "failed to decode payload")
+		return
+	}
+
+	if api.isElectra(headSlot) && payload.Electra == nil {
+		log.Warn("Not an electra payload.")
+		api.RespondError(w, http.StatusBadRequest, "Non-Electra payload detected and rejected. You need to update mev-boost!")
+		return
+	}
+
+	// Take time after the decoding, and add to logging
+	decodeTime := time.Now().UTC()
+	slot, err := payload.Slot()
+	if err != nil {
+		log.WithError(err).Warn("failed to get payload slot")
+		api.RespondError(w, http.StatusBadRequest, "failed to get payload slot")
+		return
+	}
+	blockHash, err := payload.ExecutionBlockHash()
+	if err != nil {
+		log.WithError(err).Warn("failed to get payload block hash")
+		api.RespondError(w, http.StatusBadRequest, "failed to get payload block hash")
+		return
+	}
+	proposerIndex, err := payload.ProposerIndex()
+	if err != nil {
+		log.WithError(err).Warn("failed to get payload proposer index")
+		api.RespondError(w, http.StatusBadRequest, "failed to get payload proposer index")
+		return
+	}
+	slotStartTimestamp := api.genesisInfo.Data.GenesisTime + (uint64(slot) * common.SecondsPerSlot)
+	msIntoSlot := decodeTime.UnixMilli() - int64(slotStartTimestamp*1000) //nolint:gosec
+	log = log.WithFields(logrus.Fields{
+		"slot":                 slot,
+		"slotEpochPos":         (uint64(slot) % common.SlotsPerEpoch) + 1,
+		"blockHash":            blockHash.String(),
+		"slotStartSec":         slotStartTimestamp,
+		"msIntoSlot":           msIntoSlot,
+		"timestampAfterDecode": decodeTime.UnixMilli(),
+		"proposerIndex":        proposerIndex,
+	})
+
+	// Ensure the proposer index is expected
+	api.proposerDutiesLock.RLock()
+	slotDuty := api.proposerDutiesMap[uint64(slot)]
+	api.proposerDutiesLock.RUnlock()
+	if slotDuty == nil {
+		log.Warn("could not find slot duty")
+	} else {
+		log = log.WithField("feeRecipient", slotDuty.Entry.Message.FeeRecipient.String())
+		if slotDuty.ValidatorIndex != uint64(proposerIndex) {
+			log.WithField("expectedProposerIndex", slotDuty.ValidatorIndex).Warn("not the expected proposer index")
+			api.RespondError(w, http.StatusBadRequest, "not the expected proposer index")
+			return
+		}
+	}
+
+	// Get the proposer pubkey based on the validator index from the payload
+	proposerPubkey, found := api.datastore.GetKnownValidatorPubkeyByIndex(uint64(proposerIndex))
+	if !found {
+		log.Errorf("could not find proposer pubkey for index %d", proposerIndex)
+		api.RespondError(w, http.StatusBadRequest, "could not match proposer index to pubkey")
+		return
+	}
+
+	// Add proposer pubkey to logs
+	log = log.WithField("proposerPubkey", proposerPubkey)
+
+	// Create a BLS pubkey from the hex pubkey
+	pk, err := proposerPubkey.ToPubkey()
+	if err != nil {
+		log.WithError(err).Warn("could not convert pubkey to phase0.BLSPubKey")
+		api.RespondError(w, http.StatusBadRequest, "could not convert pubkey to phase0.BLSPubKey")
+		return
+	}
+
+	// Validate proposer signature
+	ok, err := api.checkProposerSignature(payload, pk[:])
+	if !ok || err != nil {
+		if api.ffLogInvalidSignaturePayload {
+			txt, _ := json.Marshal(payload)
+			log.Info("payload_invalid_sig: ", string(txt), "pubkey:", proposerPubkey)
+		}
+		log.WithError(err).Warn("could not verify payload signature")
+		api.RespondError(w, http.StatusBadRequest, "could not verify payload signature")
+		return
+	}
+
+	// Log about received payload (with a valid proposer signature)
+	log = log.WithField("timestampAfterSignatureVerify", time.Now().UTC().UnixMilli())
+	log.Info("getPayload request received")
+
+	var getPayloadResp *builderApi.VersionedSubmitBlindedBlockResponse
+	var msNeededForPublishing uint64
+
+	// Save information about delivered payload
+	defer func() {
+		bidTrace, err := api.redis.GetBidTrace(uint64(slot), proposerPubkey.String(), blockHash.String())
+		if err != nil {
+			log.WithError(err).Info("failed to get bidTrace for delivered payload from redis")
+			return
+		}
+
+		err = api.db.SaveDeliveredPayload(bidTrace, payload, decodeTime, msNeededForPublishing)
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{
+				"bidTrace": bidTrace,
+				"payload":  payload,
+			}).Error("failed to save delivered payload")
+		}
+
+		// Increment builder stats
+		err = api.db.IncBlockBuilderStatsAfterGetPayload(bidTrace.BuilderPubkey.String())
+		if err != nil {
+			log.WithError(err).Error("failed to increment builder-stats after getPayload")
+		}
+
+		// Wait until optimistic blocks are complete.
+		api.optimisticBlocksWG.Wait()
+
+		// Check if there is a demotion for the winning block.
+		_, err = api.db.GetBuilderDemotion(bidTrace)
+		// If demotion not found, we are done!
+		if errors.Is(err, sql.ErrNoRows) {
+			log.Info("no demotion in getPayload, successful block proposal")
+			return
+		}
+		if err != nil {
+			log.WithError(err).Error("failed to read demotion table in getPayload")
+			return
+		}
+		// Demotion found, update the demotion table with refund data.
+		builderPubkey := bidTrace.BuilderPubkey.String()
+		log = log.WithFields(logrus.Fields{
+			"builderPubkey": builderPubkey,
+			"slot":          bidTrace.Slot,
+			"blockHash":     bidTrace.BlockHash,
+		})
+		log.Warn("demotion found in getPayload, inserting refund justification")
+
+		// Prepare refund data.
+		signedBeaconBlock, err := common.SignedBlindedBeaconBlockToBeaconBlock(payload, getPayloadResp)
+		if err != nil {
+			log.WithError(err).Error("failed to convert signed blinded beacon block to beacon block")
+			api.RespondError(w, http.StatusInternalServerError, "failed to convert signed blinded beacon block to beacon block")
+			return
+		}
+
+		// Get registration entry from the DB.
+		registrationEntry, err := api.db.GetValidatorRegistration(proposerPubkey.String())
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				log.WithError(err).Error("no registration found for validator " + proposerPubkey)
+			} else {
+				log.WithError(err).Error("error reading validator registration")
+			}
+		}
+		var signedRegistration *builderApiV1.SignedValidatorRegistration
+		if registrationEntry != nil {
+			signedRegistration, err = registrationEntry.ToSignedValidatorRegistration()
+			if err != nil {
+				log.WithError(err).Error("error converting registration to signed registration")
+			}
+		}
+
+		err = api.db.UpdateBuilderDemotion(bidTrace, signedBeaconBlock, signedRegistration)
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"errorWritingRefundToDB": true,
+				"bidTrace":               bidTrace,
+				"signedBeaconBlock":      signedBeaconBlock,
+				"signedRegistration":     signedRegistration,
+			}).WithError(err).Error("unable to update builder demotion with refund justification")
+		}
+	}()
+
+	// Get the response - from Redis, Memcache or DB
+	// note that recent mev-boost versions only send getPayload to relays that provided the bid
+	getPayloadResp, err = api.datastore.GetGetPayloadResponse(log, uint64(slot), proposerPubkey.String(), blockHash.String())
+	if err != nil || getPayloadResp == nil {
+		log.WithError(err).Warn("failed getting execution payload (1/2)")
+		time.Sleep(time.Duration(timeoutGetPayloadRetryMs) * time.Millisecond)
+
+		// Try again
+		getPayloadResp, err = api.datastore.GetGetPayloadResponse(log, uint64(slot), proposerPubkey.String(), blockHash.String())
+		if err != nil || getPayloadResp == nil {
+			// Still not found! Error out now.
+			if errors.Is(err, datastore.ErrExecutionPayloadNotFound) {
+				// Couldn't find the execution payload, maybe it never was submitted to our relay! Check that now
+				bid, err := api.db.GetBlockSubmissionEntry(uint64(slot), proposerPubkey.String(), blockHash.String())
+				if errors.Is(err, sql.ErrNoRows) {
+					log.Warn("failed getting execution payload (2/2) - payload not found, block was never submitted to this relay")
+					api.RespondError(w, http.StatusBadRequest, "no execution payload for this request - block was never seen by this relay")
+				} else if err != nil {
+					log.WithError(err).Error("failed getting execution payload (2/2) - payload not found, and error on checking bids")
+				} else if bid.EligibleAt.Valid {
+					log.Error("failed getting execution payload (2/2) - payload not found, but found bid in database")
+				} else {
+					log.Info("found bid but payload was never saved as bid was ineligible being below floor value")
+				}
+			} else { // some other error
+				log.WithError(err).Error("failed getting execution payload (2/2) - error")
+			}
+			api.RespondError(w, http.StatusBadRequest, "no execution payload for this request")
+			return
+		}
+	}
+
+	// Now we know this relay also has the payload
+	log = log.WithField("timestampAfterLoadResponse", time.Now().UTC().UnixMilli())
+
+	// Check whether getPayload has already been called -- TODO: do we need to allow multiple submissions of one blinded block?
+	err = api.redis.CheckAndSetLastSlotAndHashDelivered(uint64(slot), blockHash.String())
+	log = log.WithField("timestampAfterAlreadyDeliveredCheck", time.Now().UTC().UnixMilli())
+	if err != nil {
+		if errors.Is(err, datastore.ErrAnotherPayloadAlreadyDeliveredForSlot) {
+			// BAD VALIDATOR, 2x GETPAYLOAD FOR DIFFERENT PAYLOADS
+			log.Warn("validator called getPayload twice for different payload hashes")
+			api.RespondError(w, http.StatusBadRequest, "another payload for this slot was already delivered")
+			return
+		} else if errors.Is(err, datastore.ErrPastSlotAlreadyDelivered) {
+			// BAD VALIDATOR, 2x GETPAYLOAD FOR PAST SLOT
+			log.Warn("validator called getPayload for past slot")
+			api.RespondError(w, http.StatusBadRequest, "payload for this slot was already delivered")
+			return
+		} else if errors.Is(err, redis.TxFailedErr) {
+			// BAD VALIDATOR, 2x GETPAYLOAD + RACE
+			log.Warn("validator called getPayload twice (race)")
+			api.RespondError(w, http.StatusBadRequest, "payload for this slot was already delivered (race)")
+			return
+		}
+		log.WithError(err).Error("redis.CheckAndSetLastSlotAndHashDelivered failed")
+	}
+
+	// Handle early/late requests
+	if msIntoSlot < 0 {
+		// Wait until slot start (t=0) if still in the future
+		_msSinceSlotStart := time.Now().UTC().UnixMilli() - int64(slotStartTimestamp*1000) //nolint:gosec
+		if _msSinceSlotStart < 0 {
+			delayMillis := _msSinceSlotStart * -1
+			log = log.WithField("delayMillis", delayMillis)
+			log.Info("waiting until slot start t=0")
+			time.Sleep(time.Duration(delayMillis) * time.Millisecond)
+		}
+	} else if getPayloadRequestCutoffMs > 0 && msIntoSlot > int64(getPayloadRequestCutoffMs) {
+		// Reject requests after cutoff time
+		log.Warn("getPayload sent too late")
+		api.RespondError(w, http.StatusBadRequest, fmt.Sprintf("sent too late - %d ms into slot", msIntoSlot))
+
+		go func() {
+			err := api.db.InsertTooLateGetPayload(uint64(slot), proposerPubkey.String(), blockHash.String(), slotStartTimestamp, uint64(receivedAt.UnixMilli()), uint64(decodeTime.UnixMilli()), uint64(msIntoSlot)) //nolint:gosec
+			if err != nil {
+				log.WithError(err).Error("failed to insert payload too late into db")
+			}
+		}()
+		return
+	}
+
+	// Check that BlindedBlockContent fields (sent by the proposer) match our known BlockContents
+	err = EqBlindedBlockContentsToBlockContents(payload, getPayloadResp)
+	if err != nil {
+		log.WithError(err).Warn("ExecutionPayloadHeader not matching known ExecutionPayload")
+		api.RespondError(w, http.StatusBadRequest, "invalid execution payload header")
+		return
+	}
+
+	// Publish the signed beacon block via beacon-node
+	timeBeforePublish := time.Now().UTC().UnixMilli()
+	log = log.WithField("timestampBeforePublishing", timeBeforePublish)
+	signedBeaconBlock, err := common.SignedBlindedBeaconBlockToBeaconBlock(payload, getPayloadResp)
+	if err != nil {
+		log.WithError(err).Error("failed to convert signed blinded beacon block to beacon block")
+		api.RespondError(w, http.StatusInternalServerError, "failed to convert signed blinded beacon block to beacon block")
+		return
+	}
+	code, err := api.beaconClient.PublishBlock(signedBeaconBlock) // errors are logged inside
+	if err != nil || (code != http.StatusOK && code != http.StatusAccepted) {
+		log.WithError(err).WithField("code", code).Error("failed to publish block")
+		api.RespondError(w, http.StatusBadRequest, "failed to publish block")
+		return
+	}
+
+	timeAfterPublish := time.Now().UTC().UnixMilli()
+	msNeededForPublishing = uint64(timeAfterPublish - timeBeforePublish) //nolint:gosec
+	log = log.WithField("timestampAfterPublishing", timeAfterPublish)
+	log.WithField("msNeededForPublishing", msNeededForPublishing).Info("block published through beacon node")
+	metrics.PublishBlockLatencyHistogram.Record(req.Context(), float64(msNeededForPublishing))
+
+	// give the beacon network some time to propagate the block
+	time.Sleep(time.Duration(getPayloadResponseDelayMs) * time.Millisecond)
+
+	// Respond with 202 status only
+	log.Debug("responding with only accepted status code")
+	w.WriteHeader(http.StatusAccepted)
+
 	blockNumber, err := payload.ExecutionBlockNumber()
 	if err != nil {
 		log.WithError(err).Info("failed to get block number")

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1404,8 +1404,8 @@ func (api *RelayAPI) innerHandleGetPayload(w http.ResponseWriter, req *http.Requ
 	ua := req.UserAgent()
 	headSlot := api.headSlot.Load()
 	receivedAt := time.Now().UTC()
-	logFields := logrus.Fields{
-		"method":                      "getPayload",
+	log := api.log.WithFields(logrus.Fields{
+		"method":                      fmt.Sprintf("getPayload%s", version),
 		"ua":                          ua,
 		"mevBoostV":                   common.GetMevBoostVersionFromUserAgent(ua),
 		"contentLength":               req.ContentLength,
@@ -1413,15 +1413,10 @@ func (api *RelayAPI) innerHandleGetPayload(w http.ResponseWriter, req *http.Requ
 		"headSlotEpochPos":            (headSlot % common.SlotsPerEpoch) + 1,
 		"idArg":                       req.URL.Query().Get("id"),
 		"timestampRequestStart":       receivedAt.UnixMilli(),
+		"negotiatedResponseMediaType": negotiatedResponseMediaType,
 		"proposerContentType":         proposerContentType,
 		"proposerEthConsensusVersion": proposerEthConsensusVersion,
-	}
-
-	if version == HandleGetPayloadVersionV1 {
-		logFields["negotiatedResponseMediaType"] = negotiatedResponseMediaType
-	}
-
-	log := api.log.WithFields(logFields)
+	})
 
 	// Log at start and end of request
 	log.Info("request initiated")


### PR DESCRIPTION
## 📝 Summary

Introduces v2 blinded blocks endpoint which doesn't return the entire ExecutionPayload and BlobsBundle.

## ⛱ Motivation and Context

Currently the /eth/v1/builder/blinded_blocks returns the entire ExecutionPayload and BlobsBundle. This can increase network bandwidth costs for the proposer and also the request time as we increase the number of Blobs. We therefore introduce a new v2 API endpoint, /eth/v2/builder/blinded_blocks which no longer returns the fully signed unblinded payload. Instead, it returns an empty response and relies on the relay to propagate the block.

## 📚 References

https://github.com/ethereum/builder-specs/issues/119
https://github.com/ethereum/builder-specs/pull/123

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
* [ ] I have seen and agree to `CONTRIBUTING.md`
