### PR TITLE
fix: use payload slot instead of head slot in getPayload

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1454,27 +1454,27 @@ func (api *RelayAPI) innerHandleGetPayload(w http.ResponseWriter, req *http.Requ
 		api.RespondError(w, http.StatusBadRequest, "failed to decode payload")
 		return
 	}
-
-	if api.isElectra(headSlot) && payload.Electra == nil {
-		log.Warn("Not an electra payload.")
-		api.RespondError(w, http.StatusBadRequest, "Non-Electra payload detected and rejected. You need to update mev-boost!")
-		return
-	}
-
-	if api.isFulu(headSlot) && payload.Fulu == nil {
-		log.Warn("Not a fulu payload.")
-		api.RespondError(w, http.StatusBadRequest, "Non-Fulu payload detected and rejected. You need to update mev-boost!")
-		return
-	}
-
-	// Take time after the decoding, and add to logging
-	decodeTime := time.Now().UTC()
 	slot, err := payload.Slot()
 	if err != nil {
 		log.WithError(err).Warn("failed to get payload slot")
 		api.RespondError(w, http.StatusBadRequest, "failed to get payload slot")
 		return
 	}
+
+	if api.isFulu(uint64(slot)) && payload.Fulu == nil {
+		log.Warn("Not a fulu payload.")
+		api.RespondError(w, http.StatusBadRequest, "Non-Fulu payload detected and rejected. You need to update mev-boost!")
+		return
+	}
+
+	if api.isElectra(uint64(slot)) && payload.Electra == nil {
+		log.Warn("Not an electra payload.")
+		api.RespondError(w, http.StatusBadRequest, "Non-Electra payload detected and rejected. You need to update mev-boost!")
+		return
+	}
+	
+	// Take time after the decoding, and add to logging
+	decodeTime := time.Now().UTC()
 	blockHash, err := payload.ExecutionBlockHash()
 	if err != nil {
 		log.WithError(err).Warn("failed to get payload block hash")

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1472,7 +1472,7 @@ func (api *RelayAPI) innerHandleGetPayload(w http.ResponseWriter, req *http.Requ
 		api.RespondError(w, http.StatusBadRequest, "Non-Electra payload detected and rejected. You need to update mev-boost!")
 		return
 	}
-	
+
 	// Take time after the decoding, and add to logging
 	decodeTime := time.Now().UTC()
 	blockHash, err := payload.ExecutionBlockHash()

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1464,7 +1464,7 @@ func (api *RelayAPI) innerHandleGetPayload(w http.ResponseWriter, req *http.Requ
 	err = api.checkPayloadAndHeaderVersion(payload, uint64(slot), proposerEthConsensusVersion)
 	if err != nil {
 		log.WithError(err).Warn("error checking payload and header version")
-		api.RespondError(w, http.StatusBadRequest, fmt.Sprintf("error checking payload and header version: %s", err.Error()))
+		api.RespondError(w, http.StatusBadRequest, errors.Wrap(err, "error checking payload and header version").Error())
 		return
 	}
 


### PR DESCRIPTION
## 📝 Summary

In `innerGetPayload`, once the signed blinded block from the proposer is parsed. We check if the payload has correctly been parsed according to the fork. We infer the fork to check against from `headSlot` which can be incorrect during fork transitions since `headSlot` will be in the previous fork.
We need to use payload slot from the signed blinded block sent by the proposer.
Also we throw a warning if the `proposerEthConsensusVersion` does not match the fork version.

I will fix the lint issue in the main PR.

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
